### PR TITLE
New singleton logic

### DIFF
--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -76,7 +76,7 @@ configure_block(
             src/base/ConvertStdVector.cpp
             src/base/RobotInterface.cpp
             src/base/Signal.cpp
-            src/base/ToolboxSingleton.cpp
+            src/base/WholeBodySingleton.cpp
             src/base/WBBlock.cpp
     HEADERS include/base/Block.h
             include/base/BlockInformation.h
@@ -87,7 +87,7 @@ configure_block(
             include/base/ConvertStdVector.h
             include/base/RobotInterface.h
             include/base/Signal.h
-            include/base/ToolboxSingleton.h
+            include/base/WholeBodySingleton.h
             include/base/WBBlock.h
 )
 

--- a/toolbox/include/base/BlockInformation.h
+++ b/toolbox/include/base/BlockInformation.h
@@ -211,22 +211,6 @@ public:
      */
     virtual wbt::Signal getOutputPortSignal(const PortIndex idx,
                                             const VectorSize size = -1) const = 0;
-
-    // ==========================
-    // EXTERNAL LIBRARIES METHODS
-    // ==========================
-
-    /**
-     * @brief Get the wbt::RobotInterface object associated to the Block
-     * @return The pointer to the wbt::RobotInterface object
-     */
-    virtual std::weak_ptr<wbt::RobotInterface> getRobotInterface() const = 0;
-
-    /**
-     * @brief Get the iDynTree::KinDynComputations object associated to the Block
-     * @return The pointer to the iDynTree::KinDynComputations object
-     */
-    virtual std::weak_ptr<iDynTree::KinDynComputations> getKinDynComputations() const = 0;
 };
 
 struct wbt::BlockInformation::IOData

--- a/toolbox/include/base/CoderBlockInformation.h
+++ b/toolbox/include/base/CoderBlockInformation.h
@@ -64,12 +64,6 @@ public:
     getOutputPortSignal(const PortIndex idx,
                         const VectorSize size = wbt::Signal::DynamicSize) const override;
 
-    // EXTERNAL LIBRARIES METHODS
-    // ==========================
-
-    std::weak_ptr<wbt::RobotInterface> getRobotInterface() const override;
-    std::weak_ptr<iDynTree::KinDynComputations> getKinDynComputations() const override;
-
     // METHODS OUTSIDE THE INTERFACE
     // =============================
 

--- a/toolbox/include/base/Configuration.h
+++ b/toolbox/include/base/Configuration.h
@@ -27,7 +27,7 @@ namespace wbt {
  * Its usage is specific for using yarp::dev::RemoteControlBoardRemapper and
  * iDynTree::KinDynComputations objects contained in the wbt::RobotInterface class.
  *
- * @see wbt::RobotInterface, wbt::WBBlock, wbt::ToolboxSingleton, WBToolbox.Configuration Matlab
+ * @see wbt::RobotInterface, wbt::WBBlock, wbt::WholeBodySingleton, WBToolbox.Configuration Matlab
  * Class
  */
 class wbt::Configuration

--- a/toolbox/include/base/Parameters.h
+++ b/toolbox/include/base/Parameters.h
@@ -171,19 +171,6 @@ public:
      *         `dummy` otherwise.
      */
     wbt::ParameterMetadata getParameterMetadata(const ParamName& name);
-
-    /**
-     * @brief Helper function for creating wbt::Configuration objects
-     *
-     * This helper method checks if the object has all the parameters for creating a
-     * wbt::Configuration object.
-     *
-     * @param parameters The parameters set where to look.
-     * @return True if the requirements are met, false otherwise.
-     *
-     * @see ToolboxSingleton::storeConfiguration
-     */
-    static bool containConfigurationData(const wbt::Parameters& parameters);
 };
 
 // ============

--- a/toolbox/include/base/RobotInterface.h
+++ b/toolbox/include/base/RobotInterface.h
@@ -143,7 +143,7 @@ public:
     /**
      * @brief Get a Yarp interface
      *
-     * The interface is lazy-evaluated. The handling of the memory is not responbility of the
+     * The interface is lazy-evaluated. The handling of the memory is not responsibility of the
      * caller. It is handled internally.
      *
      * @param[out] interface The object that will contain the pointer to the interface.
@@ -151,34 +151,6 @@ public:
      */
     template <typename T>
     bool getInterface(T*& interface);
-
-    // LAZY EVALUATION
-    // ===============
-
-    /**
-     * @brief Handle the internal counter for using the `RemoteControlBoardRemapper`.
-     *
-     * @attention All the blocks which need to use any of the interfaces provided by
-     *            wbt::YarpInterfaces must call this function in their Block::initialize method.
-     *
-     * @return True if success, false otherwise.
-     * @see RobotInterface::releaseRemoteControlBoardRemapper
-     */
-    bool retainRemoteControlBoardRemapper();
-
-    /**
-     * @brief Handle the internal counter for using the `RemoteControlBoardRemapper`.
-     *
-     * After the call from the last instance which retained the object, the
-     * `RemoteControlBoardRemapper` and all the allocated drivers get destroyed.
-     *
-     * @attention All the blocks which need to use any of the interfaces provided by
-     *            wbt::YarpInterfaces must call this function in their Block::terminate method.
-     *
-     * @return True if success, false otherwise.
-     * @see RobotInterface::retainRemoteControlBoardRemapper
-     */
-    bool releaseRemoteControlBoardRemapper();
 };
 
 // Specialize the getInterface template

--- a/toolbox/include/base/SimulinkBlockInformation.h
+++ b/toolbox/include/base/SimulinkBlockInformation.h
@@ -70,12 +70,6 @@ public:
     getOutputPortSignal(const PortIndex idx,
                         const VectorSize size = wbt::Signal::DynamicSize) const override;
 
-    // EXTERNAL LIBRARIES METHODS
-    // ==========================
-
-    std::weak_ptr<wbt::RobotInterface> getRobotInterface() const override;
-    std::weak_ptr<iDynTree::KinDynComputations> getKinDynComputations() const override;
-
     // METHODS OUTSIDE THE INTERFACE
     // =============================
 

--- a/toolbox/include/base/ToolboxSingleton.h
+++ b/toolbox/include/base/ToolboxSingleton.h
@@ -42,7 +42,7 @@ private:
     /// Object that stores all the configurations labelled by the name of the Simulink Block's
     /// name.
     /// @see wbt::RobotInterface
-    std::unordered_map<std::string, std::shared_ptr<wbt::RobotInterface>> m_interfaces;
+    std::unordered_map<std::string, std::weak_ptr<wbt::RobotInterface>> m_interfaces;
 
 public:
     // CONSTRUCTOR / DESTRUCTOR
@@ -72,7 +72,7 @@ public:
      * @param  confKey The key describing the configuration (name of the Simulink block)
      * @return         The number of degrees of freedom. It returns -1 when failing.
      */
-    int numberOfDoFs(const std::string& confKey);
+    int numberOfDoFs(const std::string& confKey) const;
 
     // GET METHODS
     // ===========
@@ -121,7 +121,7 @@ public:
     // TOOLBOXSINGLETON CONFIGURATION
     // ==============================
 
-    /*! Saves in the singleton a new configuration \c config.
+    /** Stores in the singleton the new configuration into a RobotInterface object
      *
      * If the config is valid and hasn't been already stored, it creates a new entry
      * in ToolboxSingleton::m_interfaces. If a configuration with matching confKey is found,
@@ -132,24 +132,22 @@ public:
      *       changed.
      *
      * @param  config  The wbt::Configuration object parsed from Simulink's parameters
-     * @return         Returns \c true if configure is successful, \c false otherwise
+     * @return         Returns a shared pointer to the RobotInterface object created from
+     *                 the Configuration object.
      * @see            ToolboxSingleton::isKeyValid
      */
-    bool storeConfiguration(const Configuration& config);
+    std::shared_ptr<RobotInterface> createRobotInterface(const Configuration& config);
 
-    /*! Saves in the singleton a new configuration \c config.
+    /** Stores a new whole-body configuration and return a RobotInterface object
      *
-     * Same as ToolboxSingleton::storeConfiguration but taking a wbt::Parameters object
-     * as input.
-     *
-     * @param  parameters A wbt::Parameters object containing all the parameters to fill
-     *                    a wbt::Configuration object
-     * @return Returns \c true if configure is successful, \c false otherwise
-     * @see    ToolboxSingleton::storeConfiguration
-     * @see    wbt::Configuration
-     * @see    wbt::Parameters::containConfigurationData
+     * @param parameters A wbt::Parameters object containing all the parameters to fill
+     *                   a wbt::Configuration object
+     * @return Returns a shared pointer to the RobotInterface object created from
+     *         the Configuration object.
+     * @see    ToolboxSingleton::storeConfiguration, wbt::Configuration,
+     *         Parameters::containConfigurationData
      */
-    bool storeConfiguration(const wbt::Parameters& parameters);
+    std::shared_ptr<RobotInterface> storeConfiguration(const wbt::Parameters& parameters);
 
     /**
      * Delete the wbt::RobotInterface referred by confKey. No-op if it doesn't exist.

--- a/toolbox/include/base/WBBlock.h
+++ b/toolbox/include/base/WBBlock.h
@@ -11,6 +11,7 @@
 
 #include "Block.h"
 #include <memory>
+#include <string>
 
 namespace wbt {
     class WBBlock;
@@ -51,25 +52,23 @@ namespace iDynTree {
 class wbt::WBBlock : public wbt::Block
 {
 protected:
+    // TODO: pImpl
     struct iDynTreeRobotState;
     std::unique_ptr<iDynTreeRobotState> m_robotState;
+    std::string m_confBlockName;
+    std::shared_ptr<wbt::RobotInterface> m_robotInterface;
 
     /**
-     * @brief Helper for retrieving the iDynTree::KinDynComputations object from
-     *        wbt::BlockInformation
-     * @param blockInfo A BlockInformation object.
+     * @brief Helper for retrieving the iDynTree::KinDynComputations object
      * @return A pointer to iDynTree::KinDynComputations.
      */
-    std::weak_ptr<iDynTree::KinDynComputations>
-    getKinDynComputations(const BlockInformation* blockInfo) const;
+    std::shared_ptr<iDynTree::KinDynComputations> getKinDynComputations() const;
 
     /**
-     * @brief Helper for retrieving the wbt::RobotInterface object from
-     *        wbt::BlockInformation
-     * @param blockInfo A BlockInformation object.
+     * @brief Helper for retrieving the wbt::RobotInterface object
      * @return A pointer to wbt::RobotInterface.
      */
-    std::weak_ptr<wbt::RobotInterface> getRobotInterface(const BlockInformation* blockInfo) const;
+    const std::shared_ptr<wbt::RobotInterface> getRobotInterface() const;
 
     /**
      * @brief Helper for setting the robot state inside the iDynTree::KinDynComputations object

--- a/toolbox/include/base/WholeBodySingleton.h
+++ b/toolbox/include/base/WholeBodySingleton.h
@@ -6,15 +6,15 @@
  * GNU Lesser General Public License v2.1 or any later version.
  */
 
-#ifndef WBT_TOOLBOXSINGLETON_H
-#define WBT_TOOLBOXSINGLETON_H
+#ifndef WBT_WHOLEBODYSINGLETON_H
+#define WBT_WHOLEBODYSINGLETON_H
 
 #include <memory>
 #include <string>
 #include <unordered_map>
 
 namespace wbt {
-    class ToolboxSingleton;
+    class WholeBodySingleton;
     class RobotInterface;
     class Parameters;
     class Configuration;
@@ -25,18 +25,16 @@ namespace iDynTree {
 }
 
 /**
- * \class ToolboxSingleton ToolboxSingleton.h
- *
  * This class handles and contains configuration and devices used by all the blocks
  * allocated by a running model. It is possible obtaining a singleton of this class
- * by calling WBToolbox::sharedInstance.
+ * by calling WholeBodySingleton::sharedInstance.
  *
  * @see wbt::RobotInterface
  * @see wbt::Configuration
  * @see wbt::yarpDevices
  *
  */
-class wbt::ToolboxSingleton
+class wbt::WholeBodySingleton
 {
 private:
     /// Object that stores all the configurations labelled by the name of the Simulink Block's
@@ -48,11 +46,11 @@ public:
     // CONSTRUCTOR / DESTRUCTOR
     // ========================
 
-    ToolboxSingleton();
-    ~ToolboxSingleton();
+    WholeBodySingleton();
+    ~WholeBodySingleton();
 
-    ToolboxSingleton(const ToolboxSingleton&) = delete;
-    ToolboxSingleton& operator=(const ToolboxSingleton&) = delete;
+    WholeBodySingleton(const WholeBodySingleton&) = delete;
+    WholeBodySingleton& operator=(const WholeBodySingleton&) = delete;
 
     // UTILITIES
     // =========
@@ -86,13 +84,13 @@ public:
      *
      * @return the singleton instance
      */
-    static wbt::ToolboxSingleton& sharedInstance();
+    static wbt::WholeBodySingleton& sharedInstance();
 
     /**
      * Returns the Configuration object labelled by confKey.
      * This object is contained into the wbt::RobotInterface object.
      *
-     * @see ToolboxSingleton::getRobotInterface
+     * @see WholeBodySingleton::getRobotInterface
      * @param  confKey The key describing the configuration (name of the Simulink block)
      * @return         A constant reference to the Configuration object
      */
@@ -118,13 +116,13 @@ public:
     const std::shared_ptr<iDynTree::KinDynComputations>
     getKinDynComputations(const std::string& confKey) const;
 
-    // TOOLBOXSINGLETON CONFIGURATION
-    // ==============================
+    // WHOLEBODYSINGLETON CONFIGURATION
+    // ================================
 
     /** Stores in the singleton the new configuration into a RobotInterface object
      *
      * If the config is valid and hasn't been already stored, it creates a new entry
-     * in ToolboxSingleton::m_interfaces. If a configuration with matching confKey is found,
+     * in WholeBodySingleton::m_interfaces. If a configuration with matching confKey is found,
      * if the Configuration object is the same it does nothing, otherwise it overrides it.
      *
      * @note Since confKey is the name of the block, the overriding can happen only after
@@ -134,7 +132,7 @@ public:
      * @param  config  The wbt::Configuration object parsed from Simulink's parameters
      * @return         Returns a shared pointer to the RobotInterface object created from
      *                 the Configuration object.
-     * @see            ToolboxSingleton::isKeyValid
+     * @see            WholeBodySingleton::isKeyValid
      */
     std::shared_ptr<RobotInterface> createRobotInterface(const Configuration& config);
 
@@ -144,7 +142,7 @@ public:
      *                   a wbt::Configuration object
      * @return Returns a shared pointer to the RobotInterface object created from
      *         the Configuration object.
-     * @see    ToolboxSingleton::storeConfiguration, wbt::Configuration,
+     * @see    WholeBodySingleton::storeConfiguration, wbt::Configuration,
      *         Parameters::containConfigurationData
      */
     std::shared_ptr<RobotInterface> storeConfiguration(const wbt::Parameters& parameters);
@@ -157,4 +155,4 @@ public:
     void eraseConfiguration(const std::string& confKey);
 };
 
-#endif // WBT_TOOLBOXSINGLETON_H
+#endif // WBT_WHOLEBODYSINGLETON_H

--- a/toolbox/src/CentroidalMomentum.cpp
+++ b/toolbox/src/CentroidalMomentum.cpp
@@ -62,12 +62,7 @@ bool CentroidalMomentum::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -119,7 +114,7 @@ bool CentroidalMomentum::terminate(const BlockInformation* blockInfo)
 bool CentroidalMomentum::output(const BlockInformation* blockInfo)
 {
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/DotJNu.cpp
+++ b/toolbox/src/DotJNu.cpp
@@ -91,12 +91,7 @@ bool DotJNu::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -161,7 +156,7 @@ bool DotJNu::initialize(BlockInformation* blockInfo)
     // Check if the frame is valid
     // ---------------------------
 
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Cannot retrieve handle to KinDynComputations.";
         return false;
@@ -194,7 +189,7 @@ bool DotJNu::terminate(const BlockInformation* blockInfo)
 bool DotJNu::output(const BlockInformation* blockInfo)
 {
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/ForwardKinematics.cpp
+++ b/toolbox/src/ForwardKinematics.cpp
@@ -88,12 +88,7 @@ bool ForwardKinematics::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -154,7 +149,7 @@ bool ForwardKinematics::initialize(BlockInformation* blockInfo)
     // Check if the frame is valid
     // ---------------------------
 
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Cannot retrieve handle to KinDynComputations.";
         return false;
@@ -187,7 +182,7 @@ bool ForwardKinematics::output(const BlockInformation* blockInfo)
     using Matrix4diDynTree = Matrix<double, 4, 4, Eigen::RowMajor>;
 
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/GetLimits.cpp
+++ b/toolbox/src/GetLimits.cpp
@@ -98,12 +98,7 @@ bool GetLimits::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -162,13 +157,7 @@ bool GetLimits::initialize(BlockInformation* blockInfo)
     // ====================
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto& configuration = robotInterface->getConfiguration();
-    const auto dofs = configuration.getNumberOfDoFs();
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // Initialize the structure that stores the limits
     pImpl->limits.min.resize(dofs);
@@ -198,15 +187,9 @@ bool GetLimits::output(const BlockInformation* blockInfo)
         double min = 0;
         double max = 0;
 
-        // Get the RobotInterface
-        const auto robotInterface = getRobotInterface(blockInfo).lock();
-        if (!robotInterface) {
-            wbtError << "RobotInterface has not been correctly initialized.";
-            return false;
-        }
-        // Get the DoFs
-        const auto& configuration = robotInterface->getConfiguration();
-        const auto dofs = configuration.getNumberOfDoFs();
+        // Get the RobotInterface and the DoFs
+        const auto robotInterface = getRobotInterface();
+        const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
         // From the RemoteControlBoardRemapper
         // ===================================
@@ -268,7 +251,8 @@ bool GetLimits::output(const BlockInformation* blockInfo)
 
             for (unsigned i = 0; i < dofs; ++i) {
                 // Get the joint name
-                const std::string joint = configuration.getControlledJoints()[i];
+                const std::string joint =
+                    robotInterface->getConfiguration().getControlledJoints()[i];
 
                 // Get its index
                 iDynTree::JointIndex jointIndex = model.getJointIndex(joint);
@@ -316,13 +300,8 @@ bool GetLimits::output(const BlockInformation* blockInfo)
         return false;
     }
 
-    // Get the Configuration
-    auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    // Get the DoFs
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     bool ok = true;
     ok = ok && minPort.setBuffer(pImpl->limits.min.data(), dofs);

--- a/toolbox/src/GetLimits.cpp
+++ b/toolbox/src/GetLimits.cpp
@@ -185,19 +185,7 @@ bool GetLimits::initializeInitialConditions(const BlockInformation* /*blockInfo*
 
 bool GetLimits::terminate(const BlockInformation* blockInfo)
 {
-    bool ok = true;
-
-    // Release the RemoteControlBoardRemapper
-    if (pImpl->limitType == "ControlBoardPosition" || pImpl->limitType == "ControlBoardVelocity") {
-        auto robotInterface = getRobotInterface(blockInfo).lock();
-        if (!robotInterface || !robotInterface->releaseRemoteControlBoardRemapper()) {
-            wbtError << "Failed to release the RemoteControlBoardRemapper.";
-            ok = false;
-            // Don't return false here. WBBlock::terminate must be called in any case
-        }
-    }
-
-    return ok && WBBlock::terminate(blockInfo);
+    return WBBlock::terminate(blockInfo);
 }
 
 bool GetLimits::output(const BlockInformation* blockInfo)
@@ -228,15 +216,10 @@ bool GetLimits::output(const BlockInformation* blockInfo)
         // initialization. In this case, it matches 1:1 the controlled joint vector.
         // It is hence possible using i to point to the correct joint.
 
-        // Get the RemoteControlBoardRemapper and IControlLimits2 interface if needed
+        // Get the IControlLimits2 interface
         yarp::dev::IControlLimits2* iControlLimits2 = nullptr;
         if (pImpl->limitType == "ControlBoardPosition"
             || pImpl->limitType == "ControlBoardVelocity") {
-            // Retain the control board remapper
-            if (!robotInterface->retainRemoteControlBoardRemapper()) {
-                wbtError << "Couldn't retain the RemoteControlBoardRemapper.";
-                return false;
-            }
             // Get the interface
             if (!robotInterface->getInterface(iControlLimits2) || !iControlLimits2) {
                 wbtError << "Failed to get IControlLimits2 interface.";

--- a/toolbox/src/GetMeasurement.cpp
+++ b/toolbox/src/GetMeasurement.cpp
@@ -225,7 +225,7 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
             // Get the interface
             yarp::dev::IEncoders* iEncoders = nullptr;
             if (!robotInterface->getInterface(iEncoders) || !iEncoders) {
-                wbtError << "Failed to get IPidControl interface.";
+                wbtError << "Failed to get IEncoders interface.";
                 return false;
             }
             // Get the measurement
@@ -276,7 +276,7 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
             // Get the interface
             yarp::dev::IMotorEncoders* iMotorEncoders = nullptr;
             if (!robotInterface->getInterface(iMotorEncoders) || !iMotorEncoders) {
-                wbtError << "Failed to get ITorqueControl interface.";
+                wbtError << "Failed to get IMotorEncoders interface.";
                 return false;
             }
             // Get the measurement
@@ -288,7 +288,7 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
             // Get the interface
             yarp::dev::IMotorEncoders* iMotorEncoders = nullptr;
             if (!robotInterface->getInterface(iMotorEncoders) || !iMotorEncoders) {
-                wbtError << "Failed to get ITorqueControl interface.";
+                wbtError << "Failed to get IMotorEncoders interface.";
                 return false;
             }
             // Get the measurement
@@ -300,7 +300,7 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
             // Get the interface
             yarp::dev::IMotorEncoders* iMotorEncoders = nullptr;
             if (!robotInterface->getInterface(iMotorEncoders) || !iMotorEncoders) {
-                wbtError << "Failed to get ITorqueControl interface.";
+                wbtError << "Failed to get IMotorEncoders interface.";
                 return false;
             }
             // Get the measurement
@@ -312,7 +312,7 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
             // Get the interface
             yarp::dev::ICurrentControl* iCurrentControl = nullptr;
             if (!robotInterface->getInterface(iCurrentControl) || !iCurrentControl) {
-                wbtError << "Failed to get ITorqueControl interface.";
+                wbtError << "Failed to get ICurrentControl interface.";
                 return false;
             }
             // Get the measurement
@@ -323,7 +323,7 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
             // Get the interface
             yarp::dev::IPWMControl* iPWMControl = nullptr;
             if (!robotInterface->getInterface(iPWMControl) || !iPWMControl) {
-                wbtError << "Failed to get ITorqueControl interface.";
+                wbtError << "Failed to get IPWMControl interface.";
                 return false;
             }
             // Get the measurement

--- a/toolbox/src/GetMeasurement.cpp
+++ b/toolbox/src/GetMeasurement.cpp
@@ -108,12 +108,7 @@ bool GetMeasurement::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -202,12 +197,7 @@ bool GetMeasurement::initialize(BlockInformation* blockInfo)
     // ====================
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // Initialize the size of the output vector
     pImpl->measurement.resize(dofs);
@@ -223,11 +213,7 @@ bool GetMeasurement::terminate(const BlockInformation* blockInfo)
 bool GetMeasurement::output(const BlockInformation* blockInfo)
 {
     // Get the RobotInterface
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
+    const auto robotInterface = getRobotInterface();
 
     bool ok;
     switch (pImpl->measuredType) {

--- a/toolbox/src/GetMeasurement.cpp
+++ b/toolbox/src/GetMeasurement.cpp
@@ -212,32 +212,12 @@ bool GetMeasurement::initialize(BlockInformation* blockInfo)
     // Initialize the size of the output vector
     pImpl->measurement.resize(dofs);
 
-    // Retain the ControlBoardRemapper
-    if (!robotInterface->retainRemoteControlBoardRemapper()) {
-        wbtError << "Couldn't retain the RemoteControlBoardRemapper.";
-        return false;
-    }
-
     return true;
 }
 
 bool GetMeasurement::terminate(const BlockInformation* blockInfo)
 {
-    // Get the RobotInterface
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-
-    // Release the RemoteControlBoardRemapper
-    bool ok = robotInterface->releaseRemoteControlBoardRemapper();
-    if (!ok) {
-        wbtError << "Failed to release the RemoteControlBoardRemapper.";
-        // Don't return false here. WBBlock::terminate must be called in any case
-    }
-
-    return ok && WBBlock::terminate(blockInfo);
+    return WBBlock::terminate(blockInfo);
 }
 
 bool GetMeasurement::output(const BlockInformation* blockInfo)

--- a/toolbox/src/InverseDynamics.cpp
+++ b/toolbox/src/InverseDynamics.cpp
@@ -78,12 +78,7 @@ bool InverseDynamics::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -139,12 +134,7 @@ bool InverseDynamics::initialize(BlockInformation* blockInfo)
     using namespace iDynTree;
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // Initialize sizes and value
     pImpl->baseAcceleration.zero();
@@ -152,7 +142,7 @@ bool InverseDynamics::initialize(BlockInformation* blockInfo)
     pImpl->jointsAcceleration.zero();
 
     // Get the KinDynComputations pointer
-    const auto& kindyn = robotInterface->getKinDynComputations();
+    const auto& kindyn = getRobotInterface()->getKinDynComputations();
     if (!kindyn) {
         wbtError << "Failed to get the KinDynComputations object";
         return false;
@@ -175,7 +165,7 @@ bool InverseDynamics::terminate(const BlockInformation* blockInfo)
 bool InverseDynamics::output(const BlockInformation* blockInfo)
 {
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/Jacobian.cpp
+++ b/toolbox/src/Jacobian.cpp
@@ -95,12 +95,7 @@ bool Jacobian::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -162,7 +157,7 @@ bool Jacobian::initialize(BlockInformation* blockInfo)
     // Check if the frame is valid
     // ---------------------------
 
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Cannot retrieve handle to KinDynComputations.";
         return false;
@@ -184,12 +179,7 @@ bool Jacobian::initialize(BlockInformation* blockInfo)
     // ------------------
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     pImpl->jacobianCOM.resize(3, 6 + dofs);
     pImpl->jacobianCOM.zero();
@@ -213,7 +203,7 @@ bool Jacobian::output(const BlockInformation* blockInfo)
     using MatrixXdiDynTree = Matrix<double, Dynamic, Dynamic, Eigen::RowMajor>;
 
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/MassMatrix.cpp
+++ b/toolbox/src/MassMatrix.cpp
@@ -61,12 +61,7 @@ bool MassMatrix::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -115,12 +110,7 @@ bool MassMatrix::initialize(BlockInformation* blockInfo)
     // ------------------
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     pImpl->massMatrix.resize(6 + dofs, 6 + dofs);
     pImpl->massMatrix.zero();
@@ -141,7 +131,7 @@ bool MassMatrix::output(const BlockInformation* blockInfo)
     using MatrixXdiDynTree = Matrix<double, Dynamic, Dynamic, Eigen::RowMajor>;
 
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/ModelPartitioner.cpp
+++ b/toolbox/src/ModelPartitioner.cpp
@@ -77,14 +77,9 @@ bool ModelPartitioner::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the number of the control boards
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
-    const auto controlBoardsNumber =
-        robotInterface->getConfiguration().getControlBoardsNames().size();
+    const auto configuration = getRobotInterface()->getConfiguration();
+    const int dofs = configuration.getNumberOfDoFs();
+    const auto controlBoardsNumber = configuration.getControlBoardsNames().size();
 
     // PARAMETERS
     // ==========
@@ -163,11 +158,7 @@ bool ModelPartitioner::initialize(BlockInformation* blockInfo)
     }
 
     // Get the RobotInterface
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
+    const auto robotInterface = getRobotInterface();
 
     // PARAMETERS
     // ==========
@@ -208,14 +199,8 @@ bool ModelPartitioner::terminate(const BlockInformation* blockInfo)
 
 bool ModelPartitioner::output(const BlockInformation* blockInfo)
 {
-    // Get the RobotInterface
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-
-    // Get the Configuration
+    // Get the RobotInterface and the Configuration
+    const auto robotInterface = getRobotInterface();
     const auto& configuration = robotInterface->getConfiguration();
 
     if (pImpl->vectorToControlBoards) {

--- a/toolbox/src/RelativeTransform.cpp
+++ b/toolbox/src/RelativeTransform.cpp
@@ -93,12 +93,7 @@ bool RelativeTransform::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -163,7 +158,7 @@ bool RelativeTransform::initialize(BlockInformation* blockInfo)
     // Check if the frames are valid
     // -----------------------------
 
-    const auto kinDyn = getKinDynComputations(blockInfo).lock();
+    const auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Cannot retrieve handle to KinDynComputations.";
         return false;
@@ -202,7 +197,7 @@ bool RelativeTransform::output(const BlockInformation* blockInfo)
     using Matrix4diDynTree = Matrix<double, 4, 4, Eigen::RowMajor>;
 
     // Get the KinDynComputations object
-    auto kinDyn = getKinDynComputations(blockInfo).lock();
+    auto kinDyn = getKinDynComputations();
     if (!kinDyn) {
         wbtError << "Failed to retrieve the KinDynComputations object.";
         return false;

--- a/toolbox/src/SetLowLevelPID.cpp
+++ b/toolbox/src/SetLowLevelPID.cpp
@@ -192,12 +192,6 @@ bool SetLowLevelPID::initialize(BlockInformation* blockInfo)
         return false;
     }
 
-    // Retain the RemoteControlBoardRemapper
-    if (!robotInterface->retainRemoteControlBoardRemapper()) {
-        wbtError << "Couldn't retain the RemoteControlBoardRemapper.";
-        return false;
-    }
-
     const auto dofs = configuration.getNumberOfDoFs();
 
     // Initialize the vector size to the number of dofs
@@ -257,24 +251,17 @@ bool SetLowLevelPID::terminate(const BlockInformation* blockInfo)
     ok = robotInterface->getInterface(iPidControl);
     if (!ok || !iPidControl) {
         wbtError << "Failed to get IPidControl interface.";
-        // Don't return false here. WBBlock::terminate must be called in any case
+        return false;
     }
 
     // Reset default PID gains
     ok = iPidControl->setPids(pImpl->controlType, pImpl->defaultPidValues.data());
     if (!ok) {
         wbtError << "Failed to reset PIDs to the default values.";
-        // Don't return false here. WBBlock::terminate must be called in any case
+        return false;
     }
 
-    // Release the RemoteControlBoardRemapper
-    ok = robotInterface->releaseRemoteControlBoardRemapper();
-    if (!ok) {
-        wbtError << "Failed to release the RemoteControlBoardRemapper.";
-        // Don't return false here. WBBlock::terminate must be called in any case
-    }
-
-    return ok && WBBlock::terminate(blockInfo);
+    return WBBlock::terminate(blockInfo);
 }
 
 bool SetLowLevelPID::output(const BlockInformation* /*blockInfo*/)

--- a/toolbox/src/SetReferences.cpp
+++ b/toolbox/src/SetReferences.cpp
@@ -107,12 +107,7 @@ bool SetReferences::configureSizeAndPorts(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const int dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const int dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // INPUTS
     // ======
@@ -150,12 +145,7 @@ bool SetReferences::initialize(BlockInformation* blockInfo)
     }
 
     // Get the DoFs
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "RobotInterface has not been correctly initialized.";
-        return false;
-    }
-    const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
+    const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     // PARAMETERS
     // ==========
@@ -219,7 +209,7 @@ bool SetReferences::initialize(BlockInformation* blockInfo)
 
         // Get the interface
         yarp::dev::IPositionControl* interface = nullptr;
-        if (!robotInterface->getInterface(interface) || !interface) {
+        if (!getRobotInterface()->getInterface(interface) || !interface) {
             wbtError << "Failed to get IPositionControl interface.";
             return false;
         }
@@ -252,14 +242,8 @@ bool SetReferences::terminate(const BlockInformation* blockInfo)
     using namespace yarp::dev;
     bool ok = true;
 
-    // Get the RobotInterface
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "Couldn't get RobotInterface.";
-        return false;
-    }
-
-    // Get the DoFs
+    // Get the RobotInterface and the DoFs
+    const auto robotInterface = getRobotInterface();
     const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
 
     // Get the IControlMode2 interface
@@ -323,11 +307,7 @@ bool SetReferences::output(const BlockInformation* blockInfo)
     using namespace yarp::dev;
 
     // Get the RobotInterface
-    const auto robotInterface = getRobotInterface(blockInfo).lock();
-    if (!robotInterface) {
-        wbtError << "Couldn't get RobotInterface.";
-        return false;
-    }
+    const auto robotInterface = getRobotInterface();
 
     // Set the control mode at the first run
     if (pImpl->resetControlMode) {

--- a/toolbox/src/SetReferences.cpp
+++ b/toolbox/src/SetReferences.cpp
@@ -179,12 +179,6 @@ bool SetReferences::initialize(BlockInformation* blockInfo)
     // CLASS INITIALIZATION
     // ====================
 
-    // Retain the ControlBoardRemapper
-    if (!robotInterface->retainRemoteControlBoardRemapper()) {
-        wbtError << "Couldn't retain the RemoteControlBoardRemapper.";
-        return false;
-    }
-
     // Initialize the size of std::vectors
     pImpl->controlModes.assign(dofs, VOCAB_CM_UNKNOWN);
 
@@ -273,7 +267,7 @@ bool SetReferences::terminate(const BlockInformation* blockInfo)
     ok = robotInterface->getInterface(icmd2);
     if (!ok || !icmd2) {
         wbtError << "Failed to get the IControlMode2 interface.";
-        // Don't return false here. WBBlock::terminate must be called in any case
+        return false;
     }
 
     if (pImpl->controlModes.front() != VOCAB_CM_POSITION) {
@@ -283,7 +277,7 @@ bool SetReferences::terminate(const BlockInformation* blockInfo)
         ok = icmd2->setControlModes(pImpl->controlModes.data());
         if (!ok) {
             wbtError << "Failed to set control mode.";
-            // Don't return false here. WBBlock::terminate must be called in any case
+            return false;
         }
     }
     else { // In Position mode, restore the default reference speeds
@@ -292,26 +286,19 @@ bool SetReferences::terminate(const BlockInformation* blockInfo)
         ok = robotInterface->getInterface(interface);
         if (!ok || !interface) {
             wbtError << "Failed to get IPositionControl interface.";
-            // Don't return false here. WBBlock::terminate must be called in any case
+            return false;
         }
         // Restore default reference speeds
         if (interface) {
             ok = interface->setRefSpeeds(pImpl->defaultRefSpeed.data());
             if (!ok) {
                 wbtError << "Failed to restore default reference speed.";
-                // Don't return false here. WBBlock::terminate must be called in any case
+                return false;
             }
         }
     }
 
-    // Release the RemoteControlBoardRemapper
-    ok = robotInterface->releaseRemoteControlBoardRemapper();
-    if (!ok) {
-        wbtError << "Failed to release the RemoteControlBoardRemapper.";
-        // Don't return false here. WBBlock::terminate must be called in any case
-    }
-
-    return ok && WBBlock::terminate(blockInfo);
+    return WBBlock::terminate(blockInfo);
 }
 
 bool SetReferences::initializeInitialConditions(const BlockInformation* /*blockInfo*/)

--- a/toolbox/src/base/CoderBlockInformation.cpp
+++ b/toolbox/src/base/CoderBlockInformation.cpp
@@ -10,7 +10,6 @@
 #include "Log.h"
 #include "Parameter.h"
 #include "Parameters.h"
-#include "ToolboxSingleton.h"
 
 #include <string>
 #include <tuple>
@@ -226,24 +225,6 @@ bool CoderBlockInformation::storeRTWParameters(const Parameters& parameters)
     }
 
     pImpl->parametersFromRTW = parameters;
-
-    // This code is shared with SimulinkBlockInformation::parseParameters
-    //
-    // Check if the parameters object contains all the information for creating a
-    // Configuration object.
-    if (Parameters::containConfigurationData(parameters)) {
-        if (!ToolboxSingleton::sharedInstance().storeConfiguration(parameters)) {
-            wbtError << "Failed to store a Configuration object in the ToolboxSigleton.";
-            return false;
-        }
-        // Save the name of the Configuration block which the processed WBBlock refers to
-        if (!parameters.getParameter("ConfBlockName", pImpl->confBlockName)) {
-            wbtError << "Failed to read ConfBlockName parameter from the Parameters object "
-                     << "that should store Configuration data.";
-            return false;
-        }
-    }
-
     return true;
 }
 
@@ -315,28 +296,4 @@ bool CoderBlockInformation::setOutputSignal(const PortIndex portNumber,
 
     pImpl->outputSignals[portNumber].setWidth(numElements);
     return pImpl->outputSignals[portNumber].initializeBufferFromContiguousZeroCopy(address);
-}
-
-std::weak_ptr<wbt::RobotInterface> CoderBlockInformation::getRobotInterface() const
-{
-    if (pImpl->confBlockName.empty()) {
-        wbtError << "No ConfBlockName stored. Failed to get RobotInterface object.";
-        // Return an empty weak pointer
-        return std::weak_ptr<wbt::RobotInterface>();
-    }
-
-    ToolboxSingleton& interface = ToolboxSingleton::sharedInstance();
-    return interface.getRobotInterface(pImpl->confBlockName);
-}
-
-std::weak_ptr<iDynTree::KinDynComputations> CoderBlockInformation::getKinDynComputations() const
-{
-    if (pImpl->confBlockName.empty()) {
-        wbtError << "No ConfBlockName stored. Failed to get KinDynComputations object.";
-        // Return an empty weak pointer
-        return std::weak_ptr<iDynTree::KinDynComputations>();
-    }
-
-    ToolboxSingleton& interface = ToolboxSingleton::sharedInstance();
-    return interface.getKinDynComputations(pImpl->confBlockName);
 }

--- a/toolbox/src/base/Parameters.cpp
+++ b/toolbox/src/base/Parameters.cpp
@@ -243,14 +243,6 @@ wbt::ParameterMetadata Parameters::getParameterMetadata(const ParamName& name)
     }
 }
 
-bool Parameters::containConfigurationData(const wbt::Parameters& parameters)
-{
-    return parameters.existName("ConfBlockName") && parameters.existName("RobotName")
-           && parameters.existName("UrdfFile") && parameters.existName("LocalName")
-           && parameters.existName("ControlledJoints") && parameters.existName("ControlBoardsNames")
-           && parameters.existName("GravityVector");
-}
-
 // =========
 // TEMPLATES
 // =========

--- a/toolbox/src/base/RobotInterface.cpp
+++ b/toolbox/src/base/RobotInterface.cpp
@@ -66,25 +66,18 @@ public:
     std::shared_ptr<JointNameToIndexInControlBoardMap> jointNameToIndexInControlBoardMap;
     std::shared_ptr<ControlBoardIndexLimit> controlBoardIndexLimit;
 
-    // Configuration from Simulink Block's parameters
-    const wbt::Configuration config;
-
-    // Pointer to the RobotInterface object
-    wbt::RobotInterface* robotInterface = nullptr;
+    const wbt::Configuration config; // Configuration from Simulink Block's parameters
+    wbt::RobotInterface* robotInterface = nullptr; // Pointer to the RobotInterface object
 
     impl() = delete;
     explicit impl(const Configuration& configuration)
         : config(configuration)
     {}
 
-    void setOwner(wbt::RobotInterface* r) { robotInterface = r; }
     template <typename T>
     T* getInterfaceLazyEval(T*& interface,
                             const std::unique_ptr<yarp::dev::PolyDriver>& cbRemapper);
 
-    // ======================
-    // INITIALIZATION HELPERS
-    // ======================
     bool checkInterface(std::function<bool(double*)>& getMeasurement)
     {
         // This method is used only on interfaces which get measurements. There is an interval right
@@ -106,17 +99,8 @@ public:
         return true;
     }
 
-    /**
-     *
-     * @brief Initialize the model
-     *
-     * Initialize the iDynTree::KinDynComputations with the information contained
-     * in wbt::Configuration. It finds from the file system the urdf file and stores the object to
-     * operate on it. If the joint list contained in RobotInterface::pImpl->config is not complete,
-     * it loads a reduced model of the robot.
-     *
-     * @return True if success, false otherwise.
-     */
+    void setOwner(wbt::RobotInterface* r) { robotInterface = r; }
+
     bool initializeModel()
     {
         assert(!kinDynComp);
@@ -169,14 +153,6 @@ public:
         return kinDynComp->loadRobotModel(mdlLoader.model());
     }
 
-    /**
-     * @brief Initialize the remote controlboard remapper
-     *
-     * Configure a yarp::dev::RemoteControlBoardRemapper device in order to allow
-     * interfacing the toolbox with the robot (real or in Gazebo).
-     *
-     * @return True if success, false otherwise.
-     */
     bool initializeRemoteControlBoardRemapper()
     {
         // Initialize the network
@@ -236,10 +212,6 @@ public:
 
         return true;
     }
-
-    // =====================
-    // OTHER PRIVATE METHODS
-    // =====================
 
     /**
      * @brief Map joints between iDynTree and Yarp indices

--- a/toolbox/src/base/Signal.cpp
+++ b/toolbox/src/base/Signal.cpp
@@ -25,7 +25,7 @@ using namespace wbt;
 class Signal::impl
 {
 public:
-    int width = DynamicSize;
+    int width = Signal::DynamicSize;
     const bool isConst;
     const DataType portDataType;
     const DataFormat dataFormat;

--- a/toolbox/src/base/SimulinkBlockInformation.cpp
+++ b/toolbox/src/base/SimulinkBlockInformation.cpp
@@ -12,7 +12,6 @@
 #include "Parameter.h"
 #include "Parameters.h"
 #include "Signal.h"
-#include "ToolboxSingleton.h"
 
 #include <algorithm>
 #include <string>
@@ -720,23 +719,6 @@ bool SimulinkBlockInformation::parseParameters(wbt::Parameters& parameters)
         }
     }
 
-    // This code is shared with the CoderBlockParameter
-    //
-    // Check if the parameters object contains all the information for creating a
-    // Configuration object.
-    if (Parameters::containConfigurationData(parameters)) {
-        if (!ToolboxSingleton::sharedInstance().storeConfiguration(parameters)) {
-            wbtError << "Failed to store a Configuration object in the ToolboxSigleton.";
-            return false;
-        }
-        // Save the name of the Configuration block which the processed WBBlock refers to
-        if (!parameters.getParameter("ConfBlockName", m_confBlockName)) {
-            wbtError << "Failed to read ConfBlockName parameter from the Parameters object "
-                     << "that should store Configuration data.";
-            return false;
-        }
-    }
-
     // Remove the metadata of the parameters already parsed.
     // This is necessary for adding later more metadata and calling again this method
     // (storing again an already stored parameter raises an error).
@@ -896,16 +878,4 @@ SimulinkBlockInformation::getOutputPortData(const BlockInformation::PortIndex id
     }
 
     return std::make_tuple(idx, portDimension, dt);
-}
-
-std::weak_ptr<wbt::RobotInterface> SimulinkBlockInformation::getRobotInterface() const
-{
-    // Returns a nullptr if it fails
-    return ToolboxSingleton::sharedInstance().getRobotInterface(m_confBlockName);
-}
-
-std::weak_ptr<iDynTree::KinDynComputations> SimulinkBlockInformation::getKinDynComputations() const
-{
-    // Returns a nullptr if it fails
-    return ToolboxSingleton::sharedInstance().getKinDynComputations(m_confBlockName);
 }

--- a/toolbox/src/base/WBBlock.cpp
+++ b/toolbox/src/base/WBBlock.cpp
@@ -13,7 +13,7 @@
 #include "Parameter.h"
 #include "RobotInterface.h"
 #include "Signal.h"
-#include "ToolboxSingleton.h"
+#include "WholeBodySingleton.h"
 
 #include <Eigen/Core>
 #include <iDynTree/Core/AngularMotionVector3.h>
@@ -222,13 +222,13 @@ bool WBBlock::configureSizeAndPorts(BlockInformation* blockInfo)
     // blocks need to know configuration-dependent information such as the DoFs. We store now a
     // RobotInterface object and then again in the initialize() method.
 
-    // Ask the ToolboxSingleton to create the RobotInterface object. It will hold a weak pointer,
+    // Ask the WholeBodySingleton to create the RobotInterface object. It will hold a weak pointer,
     // returning a shared pointer that is stored here in WBBlock. This WBBlock object and all other
     // WBBlocks that share the same RobotInterface own its memory.
-    m_robotInterface = ToolboxSingleton::sharedInstance().storeConfiguration(m_parameters);
+    m_robotInterface = WholeBodySingleton::sharedInstance().storeConfiguration(m_parameters);
 
     if (!m_robotInterface) {
-        wbtError << "Failed to get the RobotInterface object from the ToolboxSingleton.";
+        wbtError << "Failed to get the RobotInterface object from the WholeBodySingleton.";
         return false;
     }
 
@@ -253,13 +253,13 @@ bool WBBlock::initialize(BlockInformation* blockInfo)
         return false;
     }
 
-    // Ask the ToolboxSingleton to create the RobotInterface object. It will hold a weak pointer,
+    // Ask the WholeBodySingleton to create the RobotInterface object. It will hold a weak pointer,
     // returning a shared pointer that is stored here in WBBlock. This WBBlock object and all other
     // WBBlocks that share the same RobotInterface own its memory.
-    m_robotInterface = ToolboxSingleton::sharedInstance().storeConfiguration(m_parameters);
+    m_robotInterface = WholeBodySingleton::sharedInstance().storeConfiguration(m_parameters);
 
     if (!m_robotInterface) {
-        wbtError << "Failed to get the RobotInterface object from the ToolboxSingleton.";
+        wbtError << "Failed to get the RobotInterface object from the WholeBodySingleton.";
         return false;
     }
 

--- a/toolbox/src/base/WBToolbox.cpp
+++ b/toolbox/src/base/WBToolbox.cpp
@@ -146,8 +146,7 @@ static void mdlInitializeSizes(SimStruct* S)
 
     // Allocate the block.
     // At this stage, the object is just temporary.
-    std::unique_ptr<wbt::Block> block =
-        std::unique_ptr<wbt::Block>(wbt::Block::instantiateBlockWithClassName(className));
+    auto block = std::unique_ptr<wbt::Block>(wbt::Block::instantiateBlockWithClassName(className));
 
     // Notify errors
     if (!block) {
@@ -375,9 +374,6 @@ static void mdlOutputs(SimStruct* S, int_T tid)
 
 static void mdlTerminate(SimStruct* S)
 {
-    // This function is called during the initialization phase, when the PWorks are not yet
-    // allocated. Only the number of elements is known at this stage.
-    // This check will pass if called after the initialize(), that stores data in the PWorks.
     if (!ssGetPWork(S)) {
         return;
     }

--- a/toolbox/src/base/WholeBodySingleton.cpp
+++ b/toolbox/src/base/WholeBodySingleton.cpp
@@ -6,7 +6,7 @@
  * GNU Lesser General Public License v2.1 or any later version.
  */
 
-#include "ToolboxSingleton.h"
+#include "WholeBodySingleton.h"
 #include "Configuration.h"
 #include "Log.h"
 #include "Parameters.h"
@@ -26,13 +26,13 @@ bool fillConfiguration(std::shared_ptr<wbt::Configuration>& configurationPtr,
 // CONSTRUCTOR / DESTRUCTOR
 // ========================
 
-ToolboxSingleton::ToolboxSingleton() = default;
-ToolboxSingleton::~ToolboxSingleton() = default;
+WholeBodySingleton::WholeBodySingleton() = default;
+WholeBodySingleton::~WholeBodySingleton() = default;
 
 // UTILITIES
 // =========
 
-int ToolboxSingleton::numberOfDoFs(const std::string& confKey) const
+int WholeBodySingleton::numberOfDoFs(const std::string& confKey) const
 {
     if (!isKeyValid(confKey)) {
         return -1;
@@ -41,7 +41,7 @@ int ToolboxSingleton::numberOfDoFs(const std::string& confKey) const
     return m_interfaces.at(confKey).lock()->getConfiguration().getNumberOfDoFs();
 }
 
-bool ToolboxSingleton::isKeyValid(const std::string& confKey) const
+bool WholeBodySingleton::isKeyValid(const std::string& confKey) const
 {
     if (m_interfaces.find(confKey) == m_interfaces.end()) {
         wbtError << "Failed to find entry in the ToolboxSingleton related to " << confKey
@@ -61,19 +61,19 @@ bool ToolboxSingleton::isKeyValid(const std::string& confKey) const
 // GET METHODS
 // ===========
 
-ToolboxSingleton& ToolboxSingleton::sharedInstance()
+WholeBodySingleton& WholeBodySingleton::sharedInstance()
 {
-    static ToolboxSingleton instance;
+    static WholeBodySingleton instance;
     return instance;
 }
 
-const Configuration& ToolboxSingleton::getConfiguration(const std::string& confKey) const
+const Configuration& WholeBodySingleton::getConfiguration(const std::string& confKey) const
 {
     return getRobotInterface(confKey)->getConfiguration();
 }
 
 const std::shared_ptr<RobotInterface>
-ToolboxSingleton::getRobotInterface(const std::string& confKey) const
+WholeBodySingleton::getRobotInterface(const std::string& confKey) const
 {
     if (!isKeyValid(confKey)) {
         return nullptr;
@@ -83,7 +83,7 @@ ToolboxSingleton::getRobotInterface(const std::string& confKey) const
 }
 
 const std::shared_ptr<iDynTree::KinDynComputations>
-ToolboxSingleton::getKinDynComputations(const std::string& confKey) const
+WholeBodySingleton::getKinDynComputations(const std::string& confKey) const
 {
     if (!isKeyValid(confKey)) {
         return nullptr;
@@ -92,10 +92,11 @@ ToolboxSingleton::getKinDynComputations(const std::string& confKey) const
     return m_interfaces.at(confKey).lock()->getKinDynComputations();
 }
 
-// TOOLBOXSINGLETON CONFIGURATION
-// ==============================
+// WHOLEBODYSINGLETON CONFIGURATION
+// ================================
 
-std::shared_ptr<RobotInterface> ToolboxSingleton::createRobotInterface(const Configuration& config)
+std::shared_ptr<RobotInterface>
+WholeBodySingleton::createRobotInterface(const Configuration& config)
 {
     if (!config.isValid()) {
         wbtError << "The passed configuration object does not contain valid data.";
@@ -183,7 +184,7 @@ bool fillConfiguration(std::shared_ptr<wbt::Configuration>& configurationPtr,
 }
 
 std::shared_ptr<RobotInterface>
-ToolboxSingleton::storeConfiguration(const wbt::Parameters& parameters)
+WholeBodySingleton::storeConfiguration(const wbt::Parameters& parameters)
 {
     std::shared_ptr<Configuration> configurationPtr = nullptr;
 
@@ -200,7 +201,7 @@ ToolboxSingleton::storeConfiguration(const wbt::Parameters& parameters)
     }
 
     // Create a RobotInterface from the Configuration block. A weak pointer is stored in the
-    // ToolboxSingleton and a shared pointer is returned to the caller (which owns the memory)
+    // WholeBodySingleton and a shared pointer is returned to the caller (which owns the memory)
     auto robotInterface = createRobotInterface(*configurationPtr);
 
     if (!robotInterface) {
@@ -211,7 +212,7 @@ ToolboxSingleton::storeConfiguration(const wbt::Parameters& parameters)
     return robotInterface;
 }
 
-void ToolboxSingleton::eraseConfiguration(const std::string& confKey)
+void WholeBodySingleton::eraseConfiguration(const std::string& confKey)
 {
     m_interfaces.erase(confKey);
 }


### PR DESCRIPTION
This is probably one of the biggest architecture change the wb-toolbox received after its refactoring from `WBI-Toolbox` 1.0.

The singleton among releases (2.0, 3.0, and the upcoming 4) always underwent changes, all towards a very defined direction. Its name changed accordingly.

A quick history overview:

- In the release 2.0 it was called `WBIInterface`, and it was handling the deprecated layer of the `whole-body-interface`. It was used by the old `WBIModelBlock` and `WBIBlock` classes. Model and the robot resources were managed internally by the yarp implementation of the `whole-body-interface`.
- The release 3.0 deprecated the `whole-body-interface` and substituted it directly with `iDynTree` calls and the interfacing with the robot was performed directly with the `RemoteControlBoardRemapper`. In this release a new `RobotInterface` class was introduced to store the `iDynTree` and `Yarp` resources, and a lot of logic previously contained in the `WBIInterface` singleton were moved in this new class. Since the interface deprecation, the singleton was renamed to `ToolboxSingleton`. As already mentioned, its functionalities shrunk, and it became a container with a singleton fashion of many `RobotInterface` objects (for the multi robot support). Due to this switch, some of the logic for gathering `iDynTree` and `Yarp` resources by the `Block`s required to temporary modify the `BlockInformation` interface adding calls to gather `KinDynComputations` and `RobotInterface` objects.
- The upcoming release 4 is a preparation release for splitting the core component of wb-toolbox, and this means that core classes contained in the `base` subfolders should be completely independent by these external dependencies. The singleton, which handle these resources, should not be part of this core component. This PR handled this last missing step.

In more detail, this PR introduces the following changes:

- `RobotInterface` and `KinDynComputations` are not gathered anymore from the `BlockInformation` interface. `WBBlock`s which need these resources ask them directly from the singleton. This didn't require a massive block refactoring because `WBBlock` already contained an helper method to gather these resources from the `BlockInformation` interface. Changing this method to ask them from the singleton was enough to implement this change.
- Since now only `WBBlock` instances need this singleton and these two entities are independent from the toolbox core, the singleton name changed again (hopefully for the last time) to `WholeBodySingleton`.
- **Important:** The singleton does not own anymore the memory of the `RobotInterface` object. Its ownership has been moved directly to the `WBBlock`s instances as a shared pointer (so many `WBBlock`s that share the same robot can use the same model and yarp interfaces), and the singleton only holds a weak pointer to the shared `RobotInterface`. This is required because the purpose of the singleton is to implement the logic for let this sharing happen, since single `WBBlock`s don't know anything about other `WBBlock`s.
- This change of ownership allowed to remove the hacky counter and retain / release logic for allocating and freeing the `RemoteControlBoardRemapper` device. Since it is contained by the `RobotInterface` object, which is shared among blocks, when the last block owning its memory get deleted, the `RobotInterface` is destructed, with its internal `RemoteControlBoardRemapper` object.
- As a consequence, this new logic greatly improves the robustness of the singleton, solving https://github.com/robotology/wb-toolbox/issues/94. It is more difficult now to reach a dirty state. Even if the `terminate` method is not called (which previously was deallocating with a counter the `RemoteControlBoardRemapper`), it is enough that the S-Function calls the `mdlTerminate` callback that destruct the objects in order to reach a clean state. And this is enforced by properly setting the Simulink engine.

Ok, pau for now. This was a long post but I though it was worth to store this information somewhere and this PR marks the end of a long refactoring path.

cc @traversaro @francesco-romano @DanielePucci  