### PR TITLE
Switched to Yarp 3: updated interfaces and removed ConstString

### DIFF
--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -5,7 +5,11 @@
 # FIND DEPENDENCIES
 # =================
 
-find_package(YARP REQUIRED)
+if(MSVC)
+    find_package(YARP REQUIRED)
+else()
+    find_package(YARP 2.3.73.3 REQUIRED)
+endif()
 
 # Fail if YARP is not compiled as shared library
 # see https://github.com/robotology/codyco-modules/issues/44

--- a/toolbox/include/base/RobotInterface.h
+++ b/toolbox/include/base/RobotInterface.h
@@ -21,11 +21,11 @@ namespace yarp {
         class IVelocityControl;
         class ITorqueControl;
         class IPWMControl;
-        class IControlMode2;
+        class IControlMode;
         class ICurrentControl;
         class IEncoders;
         class IMotorEncoders;
-        class IControlLimits2;
+        class IControlLimits;
         class IPidControl;
     } // namespace dev
 } // namespace yarp
@@ -156,7 +156,7 @@ public:
 // Specialize the getInterface template
 namespace wbt {
     template <>
-    bool RobotInterface::getInterface(yarp::dev::IControlMode2*& interface);
+    bool RobotInterface::getInterface(yarp::dev::IControlMode*& interface);
     template <>
     bool RobotInterface::getInterface(yarp::dev::IPositionControl*& interface);
     template <>
@@ -174,7 +174,7 @@ namespace wbt {
     template <>
     bool RobotInterface::getInterface(yarp::dev::IMotorEncoders*& interface);
     template <>
-    bool RobotInterface::getInterface(yarp::dev::IControlLimits2*& interface);
+    bool RobotInterface::getInterface(yarp::dev::IControlLimits*& interface);
     template <>
     bool RobotInterface::getInterface(yarp::dev::IPidControl*& interface);
 } // namespace wbt

--- a/toolbox/src/GetLimits.cpp
+++ b/toolbox/src/GetLimits.cpp
@@ -19,7 +19,7 @@
 #include <iDynTree/Model/IJoint.h>
 #include <iDynTree/Model/Indices.h>
 #include <iDynTree/Model/Model.h>
-#include <yarp/dev/IControlLimits2.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
 
 #include <cmath>
 #include <limits>
@@ -200,7 +200,7 @@ bool GetLimits::output(const BlockInformation* blockInfo)
         // It is hence possible using i to point to the correct joint.
 
         // Get the IControlLimits2 interface
-        yarp::dev::IControlLimits2* iControlLimits2 = nullptr;
+        yarp::dev::IControlLimits* iControlLimits2 = nullptr;
         if (pImpl->limitType == "ControlBoardPosition"
             || pImpl->limitType == "ControlBoardVelocity") {
             // Get the interface

--- a/toolbox/src/SetReferences.cpp
+++ b/toolbox/src/SetReferences.cpp
@@ -15,15 +15,14 @@
 #include "RobotInterface.h"
 #include "Signal.h"
 
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IControlMode.h>
 #include <yarp/dev/ICurrentControl.h>
 #include <yarp/dev/IPWMControl.h>
 #include <yarp/dev/IPositionControl.h>
 #include <yarp/dev/IPositionDirect.h>
 #include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/IVelocityControl.h>
-
-#include <yarp/dev/IControlMode.h>
-#include <yarp/dev/IControlMode2.h>
 
 #include <cmath>
 #include <ostream>
@@ -247,7 +246,7 @@ bool SetReferences::terminate(const BlockInformation* blockInfo)
     const auto dofs = robotInterface->getConfiguration().getNumberOfDoFs();
 
     // Get the IControlMode2 interface
-    IControlMode2* icmd2 = nullptr;
+    IControlMode* icmd2 = nullptr;
     ok = robotInterface->getInterface(icmd2);
     if (!ok || !icmd2) {
         wbtError << "Failed to get the IControlMode2 interface.";
@@ -313,7 +312,7 @@ bool SetReferences::output(const BlockInformation* blockInfo)
     if (pImpl->resetControlMode) {
         pImpl->resetControlMode = false;
         // Get the interface
-        IControlMode2* icmd2 = nullptr;
+        IControlMode* icmd2 = nullptr;
         if (!robotInterface->getInterface(icmd2) || !icmd2) {
             wbtError << "Failed to get the IControlMode2 interface.";
             return false;

--- a/toolbox/src/base/RobotInterface.cpp
+++ b/toolbox/src/base/RobotInterface.cpp
@@ -16,8 +16,6 @@
 #include <iDynTree/Model/Model.h>
 #include <iDynTree/ModelIO/ModelLoader.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
-#include <yarp/dev/IControlLimits2.h>
-#include <yarp/dev/IEncoders.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/Network.h>
@@ -40,7 +38,7 @@ using namespace wbt;
 
 struct YarpInterfaces
 {
-    yarp::dev::IControlMode2* iControlMode2 = nullptr;
+    yarp::dev::IControlMode* iControlMode = nullptr;
     yarp::dev::IPositionControl* iPositionControl = nullptr;
     yarp::dev::IPositionDirect* iPositionDirect = nullptr;
     yarp::dev::IVelocityControl* iVelocityControl = nullptr;
@@ -49,7 +47,7 @@ struct YarpInterfaces
     yarp::dev::ICurrentControl* iCurrentControl = nullptr;
     yarp::dev::IEncoders* iEncoders = nullptr;
     yarp::dev::IMotorEncoders* iMotorEncoders = nullptr;
-    yarp::dev::IControlLimits2* iControlLimits2 = nullptr;
+    yarp::dev::IControlLimits* iControlLimits = nullptr;
     yarp::dev::IPidControl* iPidControl = nullptr;
 };
 
@@ -122,7 +120,7 @@ public:
         using namespace yarp::os;
         Network network;
         ResourceFinder& rf = ResourceFinder::getResourceFinderSingleton();
-        rf.configure(0, 0);
+        rf.configure(0, nullptr);
 
         // Get the absolute path of the urdf file
         std::string urdf_file = config.getUrdfFile();
@@ -268,9 +266,7 @@ public:
             int found = -1;
             // Iterate all the joints in the selected Control Board
             for (unsigned axis = 0; axis < numAxes; ++axis) {
-                // TODO: when also in Windows ConstString will not wrap anymore std::string, use
-                // std::string
-                yarp::os::ConstString axisName;
+                std::string axisName;
                 if (!iAxisInfoPtr->getAxisName(axis, axisName)) {
                     wbtError << "Unable to get AxisName from " << remoteName << ".";
                     return false;
@@ -505,10 +501,9 @@ T* RobotInterface::impl::getInterfaceLazyEval(
 }
 
 template <>
-bool RobotInterface::getInterface(yarp::dev::IControlMode2*& interface)
+bool RobotInterface::getInterface(yarp::dev::IControlMode*& interface)
 {
-    interface =
-        pImpl->getInterfaceLazyEval(pImpl->yarpInterfaces.iControlMode2, pImpl->robotDevice);
+    interface = pImpl->getInterfaceLazyEval(pImpl->yarpInterfaces.iControlMode, pImpl->robotDevice);
     return static_cast<bool>(interface);
 }
 
@@ -652,10 +647,10 @@ bool RobotInterface::getInterface(yarp::dev::IMotorEncoders*& interface)
 }
 
 template <>
-bool RobotInterface::getInterface(yarp::dev::IControlLimits2*& interface)
+bool RobotInterface::getInterface(yarp::dev::IControlLimits*& interface)
 {
     interface =
-        pImpl->getInterfaceLazyEval(pImpl->yarpInterfaces.iControlLimits2, pImpl->robotDevice);
+        pImpl->getInterfaceLazyEval(pImpl->yarpInterfaces.iControlLimits, pImpl->robotDevice);
     return interface;
 }
 


### PR DESCRIPTION
Only minor changes are needed for the upcoming Yarp release. Fixes https://github.com/robotology/wb-toolbox/issues/119.