### PR TITLE
Signal const correctness

### DIFF
--- a/doc/release/v4.md
+++ b/doc/release/v4.md
@@ -22,6 +22,7 @@ This is the first release for which a changelog was introduced.
 - `BlockInformation` interface has been polished. Now it uses enums and const arguments.
 - `BlockInformation` interface has new methods for handling parameters.
 - `BlockInformation` does not contain anymore any reference to external dependencies (e.g. Yarp and iDynTree).
+- `BlockInformation` returns const input signals.
 - Implemented new logic for parsing parameters. Added `ConvertStdVector` helper and `Parameter` `Parameters` classes.
 - `Log` switched to a `stringstream` implementation, and the verbosity automatically changes between `Debug` and `Release`.
 - All the templates have been moved in the `cpp` file, and the allowed instantiations are now explicitly specialized or declared in the header.
@@ -55,6 +56,7 @@ This is the first release for which a changelog was introduced.
 - Fixed the `Position` control mode of the _SetReferences_ block. It now streams new references only when they change.
 - Aligned the unit of measurement of the `Reference Speed` used in the `Position` control mode of the _SetReferences_ block.
 - Restore the default `Reference Speed` when _SetReferences_ terminates.
+- Fixed bug which allowed modifying Signal's buffer content from an const object.
 
 ### `WBToolboxMex`
 

--- a/toolbox/include/base/BlockInformation.h
+++ b/toolbox/include/base/BlockInformation.h
@@ -198,8 +198,8 @@ public:
      * @return The signal connected to the input port for success, an invalid signal otherwise.
      * @see Signal::isValid
      */
-    virtual wbt::Signal getInputPortSignal(const PortIndex idx,
-                                           const VectorSize size = -1) const = 0;
+    virtual const wbt::Signal getInputPortSignal(const PortIndex idx,
+                                                 const VectorSize size = -1) const = 0;
 
     /**
      * @brief Get the signal connected to a 1D output port

--- a/toolbox/include/base/BlockInformation.h
+++ b/toolbox/include/base/BlockInformation.h
@@ -9,6 +9,7 @@
 #ifndef WBT_BLOCKINFORMATION_H
 #define WBT_BLOCKINFORMATION_H
 
+#include <memory>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -16,11 +17,13 @@
 
 namespace wbt {
     class BlockInformation;
-    class Signal;
     class ParameterMetadata;
     class Parameters;
     class Configuration;
     class RobotInterface;
+    class Signal;
+    using InputSignalPtr = std::shared_ptr<const wbt::Signal>;
+    using OutputSignalPtr = std::shared_ptr<wbt::Signal>;
     enum class DataType;
     // List of possible key for defining block options:
     extern const std::string BlockOptionPrioritizeOrder;
@@ -195,22 +198,22 @@ public:
      *
      * @param idx The index of the port.
      * @param size The size of the signal.
-     * @return The signal connected to the input port for success, an invalid signal otherwise.
-     * @see Signal::isValid
+     * @return The pointer to the signal connected to the input port for success, a `nullptr`
+     *         otherwise.
      */
-    virtual const wbt::Signal getInputPortSignal(const PortIndex idx,
-                                                 const VectorSize size = -1) const = 0;
+    virtual wbt::InputSignalPtr getInputPortSignal(const PortIndex idx,
+                                                   const VectorSize size = -1) const = 0;
 
     /**
      * @brief Get the signal connected to a 1D output port
      *
      * @param idx The index of the port.
      * @param size The size of the signal.
-     * @return The signal connected to the output port for success, an invalid signal otherwise.
-     * @see Signal::isValid
+     *@return The pointer to the signal connected to the output port for success, a `nullptr`
+     *         otherwise.
      */
-    virtual wbt::Signal getOutputPortSignal(const PortIndex idx,
-                                            const VectorSize size = -1) const = 0;
+    virtual wbt::OutputSignalPtr getOutputPortSignal(const PortIndex idx,
+                                                     const VectorSize size = -1) const = 0;
 };
 
 struct wbt::BlockInformation::IOData

--- a/toolbox/include/base/CoderBlockInformation.h
+++ b/toolbox/include/base/CoderBlockInformation.h
@@ -58,10 +58,10 @@ public:
     // BLOCK SIGNALS
     // =============
 
-    const wbt::Signal
+    wbt::InputSignalPtr
     getInputPortSignal(const PortIndex idx,
                        const VectorSize size = wbt::Signal::DynamicSize) const override;
-    wbt::Signal
+    wbt::OutputSignalPtr
     getOutputPortSignal(const PortIndex idx,
                         const VectorSize size = wbt::Signal::DynamicSize) const override;
 

--- a/toolbox/include/base/CoderBlockInformation.h
+++ b/toolbox/include/base/CoderBlockInformation.h
@@ -58,8 +58,9 @@ public:
     // BLOCK SIGNALS
     // =============
 
-    wbt::Signal getInputPortSignal(const PortIndex idx,
-                                   const VectorSize size = wbt::Signal::DynamicSize) const override;
+    const wbt::Signal
+    getInputPortSignal(const PortIndex idx,
+                       const VectorSize size = wbt::Signal::DynamicSize) const override;
     wbt::Signal
     getOutputPortSignal(const PortIndex idx,
                         const VectorSize size = wbt::Signal::DynamicSize) const override;

--- a/toolbox/include/base/Signal.h
+++ b/toolbox/include/base/Signal.h
@@ -87,8 +87,7 @@ public:
     };
 
     Signal(const DataFormat& dataFormat = DataFormat::CONTIGUOUS_ZEROCOPY,
-           const DataType& dataType = DataType::DOUBLE,
-           const bool& isConst = true);
+           const DataType& dataType = DataType::DOUBLE);
     ~Signal();
 
     Signal(const Signal& other);
@@ -148,16 +147,6 @@ public:
     bool isValid() const;
 
     /**
-     * @brief Check if the object a constant signal
-     *
-     * A constant Signal object can only read data from its buffer. It is widely used for input
-     * signals.
-     *
-     * @return True if the signal is constant, false otherwise.
-     */
-    bool isConst() const;
-
-    /**
      * @brief Read the width of the signal
      *
      * By default the width of Signal is Signal::DynamicSize. However, for being a valid signal, an
@@ -201,7 +190,16 @@ public:
      * @see Signal::setBuffer
      */
     template <typename T>
-    T* getBuffer() const;
+    T* getBuffer();
+
+    /**
+     * @brief Get the pointer to the buffer storing signal's data
+     *
+     * Documented in Signal::getBuffer
+     *
+     */
+    template <typename T>
+    const T* getBuffer() const;
 
     /**
      * @brief Get a single element of the signal
@@ -261,7 +259,8 @@ public:
 
 namespace wbt {
     // DataType::DOUBLE
-    extern template double* Signal::getBuffer<double>() const;
+    extern template double* Signal::getBuffer<double>();
+    extern template const double* Signal::getBuffer<double>() const;
     extern template double Signal::get<double>(const unsigned& i) const;
     extern template bool Signal::setBuffer<double>(const double* data, const unsigned& length);
 } // namespace wbt

--- a/toolbox/include/base/Signal.h
+++ b/toolbox/include/base/Signal.h
@@ -213,14 +213,14 @@ public:
      *         type otherwise.
      */
     template <typename T>
-    T get(const unsigned& i) const;
+    T get(const unsigned i) const;
 
     /**
      * @brief Set the width of the signal
      *
      * @param width The width to set.
      */
-    void setWidth(const unsigned& width);
+    void setWidth(const unsigned width);
 
     /**
      * @brief Set the value of a sigle element of the buffer
@@ -231,7 +231,7 @@ public:
      *
      * @todo Port this to a template
      */
-    bool set(const unsigned& index, const double& data);
+    bool set(const unsigned index, const double data);
 
     /**
      * @brief Set the pointer to the buffer storing signal's data
@@ -248,7 +248,7 @@ public:
      * @return True if the buffer was set sucessfully, false otherwise.
      */
     template <typename T>
-    bool setBuffer(const T* data, const unsigned& length);
+    bool setBuffer(const T* data, const unsigned length);
 };
 
 // Explicit declaration of templates for all the supported types
@@ -261,8 +261,8 @@ namespace wbt {
     // DataType::DOUBLE
     extern template double* Signal::getBuffer<double>();
     extern template const double* Signal::getBuffer<double>() const;
-    extern template double Signal::get<double>(const unsigned& i) const;
-    extern template bool Signal::setBuffer<double>(const double* data, const unsigned& length);
+    extern template double Signal::get<double>(const unsigned i) const;
+    extern template bool Signal::setBuffer<double>(const double* data, const unsigned length);
 } // namespace wbt
 
 #endif // WBT_SIGNAL_H

--- a/toolbox/include/base/SimulinkBlockInformation.h
+++ b/toolbox/include/base/SimulinkBlockInformation.h
@@ -67,8 +67,9 @@ public:
     // BLOCK SIGNALS
     // =============
 
-    wbt::Signal getInputPortSignal(const PortIndex idx,
-                                   const VectorSize size = wbt::Signal::DynamicSize) const override;
+    const wbt::Signal
+    getInputPortSignal(const PortIndex idx,
+                       const VectorSize size = wbt::Signal::DynamicSize) const override;
     wbt::Signal
     getOutputPortSignal(const PortIndex idx,
                         const VectorSize size = wbt::Signal::DynamicSize) const override;

--- a/toolbox/include/base/SimulinkBlockInformation.h
+++ b/toolbox/include/base/SimulinkBlockInformation.h
@@ -67,10 +67,10 @@ public:
     // BLOCK SIGNALS
     // =============
 
-    const wbt::Signal
+    wbt::InputSignalPtr
     getInputPortSignal(const PortIndex idx,
                        const VectorSize size = wbt::Signal::DynamicSize) const override;
-    wbt::Signal
+    wbt::OutputSignalPtr
     getOutputPortSignal(const PortIndex idx,
                         const VectorSize size = wbt::Signal::DynamicSize) const override;
 

--- a/toolbox/include/base/WBBlock.h
+++ b/toolbox/include/base/WBBlock.h
@@ -18,6 +18,7 @@ namespace wbt {
     class Signal;
     class BlockInformation;
     class RobotInterface;
+    using InputSignalPtr = std::shared_ptr<const Signal>;
 } // namespace wbt
 
 namespace iDynTree {
@@ -82,10 +83,10 @@ protected:
      *
      * @see iDynTree::KinDynComputations::setRobotState, wbt::iDynTreeRobotState
      */
-    bool setRobotState(const wbt::Signal* basePose,
-                       const wbt::Signal* jointsPos,
-                       const wbt::Signal* baseVelocity,
-                       const wbt::Signal* jointsVelocity,
+    bool setRobotState(wbt::InputSignalPtr basePose,
+                       wbt::InputSignalPtr jointsPos,
+                       wbt::InputSignalPtr baseVelocity,
+                       wbt::InputSignalPtr jointsVelocity,
                        iDynTree::KinDynComputations* kinDyn);
 
 public:

--- a/toolbox/src/CentroidalMomentum.cpp
+++ b/toolbox/src/CentroidalMomentum.cpp
@@ -123,19 +123,18 @@ bool CentroidalMomentum::output(const BlockInformation* blockInfo)
     // GET THE SIGNALS POPULATE THE ROBOT STATE
     // ========================================
 
-    const Signal basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
-    const Signal jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
-    const Signal baseVelocitySignal = blockInfo->getInputPortSignal(InputIndex::BaseVelocity);
-    const Signal jointsVelocitySignal = blockInfo->getInputPortSignal(InputIndex::JointVelocity);
+    InputSignalPtr basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
+    InputSignalPtr jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
+    InputSignalPtr baseVelocitySignal = blockInfo->getInputPortSignal(InputIndex::BaseVelocity);
+    InputSignalPtr jointsVelocitySignal = blockInfo->getInputPortSignal(InputIndex::JointVelocity);
 
-    if (!basePoseSig.isValid() || !jointsPosSig.isValid() || !baseVelocitySignal.isValid()
-        || !jointsVelocitySignal.isValid()) {
+    if (!basePoseSig || !jointsPosSig || !baseVelocitySignal || !jointsVelocitySignal) {
         wbtError << "Input signals not valid.";
         return false;
     }
 
     bool ok = setRobotState(
-        &basePoseSig, &jointsPosSig, &baseVelocitySignal, &jointsVelocitySignal, kinDyn.get());
+        basePoseSig, jointsPosSig, baseVelocitySignal, jointsVelocitySignal, kinDyn.get());
 
     if (!ok) {
         wbtError << "Failed to set the robot state.";
@@ -149,14 +148,14 @@ bool CentroidalMomentum::output(const BlockInformation* blockInfo)
     pImpl->centroidalMomentum = kinDyn->getCentroidalTotalMomentum();
 
     // Get the output signal
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::CentroidalMomentum);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::CentroidalMomentum);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
 
     // Fill the output buffer
-    if (!output.setBuffer(toEigen(pImpl->centroidalMomentum).data(), output.getWidth())) {
+    if (!output->setBuffer(toEigen(pImpl->centroidalMomentum).data(), output->getWidth())) {
         wbtError << "Failed to set output buffer.";
         return false;
     }

--- a/toolbox/src/DiscreteFilter.cpp
+++ b/toolbox/src/DiscreteFilter.cpp
@@ -296,24 +296,24 @@ bool DiscreteFilter::output(const BlockInformation* blockInfo)
     }
 
     // Get the input and output signals
-    const Signal inputSignal = blockInfo->getInputPortSignal(InputIndex::InputSignal);
-    Signal outputSignal = blockInfo->getOutputPortSignal(OutputIndex::FilteredSignal);
+    InputSignalPtr inputSignal = blockInfo->getInputPortSignal(InputIndex::InputSignal);
+    OutputSignalPtr outputSignal = blockInfo->getOutputPortSignal(OutputIndex::FilteredSignal);
 
-    if (!inputSignal.isValid() || !outputSignal.isValid()) {
+    if (!inputSignal || !outputSignal) {
         wbtError << "Signals not valid.";
         return false;
     }
 
     // Copy the Signal to the data structure that the filter wants
-    for (unsigned i = 0; i < inputSignal.getWidth(); ++i) {
-        pImpl->inputSignalVector[i] = inputSignal.get<double>(i);
+    for (unsigned i = 0; i < inputSignal->getWidth(); ++i) {
+        pImpl->inputSignalVector[i] = inputSignal->get<double>(i);
     }
 
     // Filter the current component of the input signal
     const Vector& outputVector = pImpl->filter->filt(pImpl->inputSignalVector);
 
     // Forward the filtered signals to the output port
-    if (!outputSignal.setBuffer(outputVector.data(), outputVector.length())) {
+    if (!outputSignal->setBuffer(outputVector.data(), outputVector.length())) {
         wbtError << "Failed to set output buffer.";
         return false;
     }

--- a/toolbox/src/DotJNu.cpp
+++ b/toolbox/src/DotJNu.cpp
@@ -198,19 +198,18 @@ bool DotJNu::output(const BlockInformation* blockInfo)
     // GET THE SIGNALS POPULATE THE ROBOT STATE
     // ========================================
 
-    const Signal basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
-    const Signal jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
-    const Signal baseVelocitySignal = blockInfo->getInputPortSignal(InputIndex::BaseVelocity);
-    const Signal jointsVelocitySignal = blockInfo->getInputPortSignal(InputIndex::JointVelocity);
+    InputSignalPtr basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
+    InputSignalPtr jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
+    InputSignalPtr baseVelocitySignal = blockInfo->getInputPortSignal(InputIndex::BaseVelocity);
+    InputSignalPtr jointsVelocitySignal = blockInfo->getInputPortSignal(InputIndex::JointVelocity);
 
-    if (!basePoseSig.isValid() || !jointsPosSig.isValid() || !baseVelocitySignal.isValid()
-        || !jointsVelocitySignal.isValid()) {
+    if (!basePoseSig || !jointsPosSig || !baseVelocitySignal || !jointsVelocitySignal) {
         wbtError << "Input signals not valid.";
         return false;
     }
 
     bool ok = setRobotState(
-        &basePoseSig, &jointsPosSig, &baseVelocitySignal, &jointsVelocitySignal, kinDyn.get());
+        basePoseSig, jointsPosSig, baseVelocitySignal, jointsVelocitySignal, kinDyn.get());
 
     if (!ok) {
         wbtError << "Failed to set the robot state.";
@@ -230,13 +229,13 @@ bool DotJNu::output(const BlockInformation* blockInfo)
     }
 
     // Forward the output to Simulink
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::DotJNu);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::DotJNu);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
 
-    if (!output.setBuffer(pImpl->dotJNu.data(), output.getWidth())) {
+    if (!output->setBuffer(pImpl->dotJNu.data(), output->getWidth())) {
         wbtError << "Failed to set output buffer.";
     }
 

--- a/toolbox/src/ForwardKinematics.cpp
+++ b/toolbox/src/ForwardKinematics.cpp
@@ -191,15 +191,15 @@ bool ForwardKinematics::output(const BlockInformation* blockInfo)
     // GET THE SIGNALS POPULATE THE ROBOT STATE
     // ========================================
 
-    const Signal basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
-    const Signal jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
+    InputSignalPtr basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
+    InputSignalPtr jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
 
-    if (!basePoseSig.isValid() || !jointsPosSig.isValid()) {
+    if (!basePoseSig || !jointsPosSig) {
         wbtError << "Input signals not valid.";
         return false;
     }
 
-    bool ok = setRobotState(&basePoseSig, &jointsPosSig, nullptr, nullptr, kinDyn.get());
+    bool ok = setRobotState(basePoseSig, jointsPosSig, nullptr, nullptr, kinDyn.get());
 
     if (!ok) {
         wbtError << "Failed to set the robot state.";
@@ -220,8 +220,8 @@ bool ForwardKinematics::output(const BlockInformation* blockInfo)
     }
 
     // Get the output signal memory location
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::Transform);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::Transform);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
@@ -229,7 +229,7 @@ bool ForwardKinematics::output(const BlockInformation* blockInfo)
     // Allocate objects for row-major -> col-major conversion
     Map<const Matrix4diDynTree> world_H_frame_RowMajor =
         toEigen(world_H_frame.asHomogeneousTransform());
-    Map<Matrix4dSimulink> world_H_frame_ColMajor(output.getBuffer<double>(), 4, 4);
+    Map<Matrix4dSimulink> world_H_frame_ColMajor(output->getBuffer<double>(), 4, 4);
 
     // Forward the buffer to Simulink transforming it to ColMajor
     world_H_frame_ColMajor = world_H_frame_RowMajor;

--- a/toolbox/src/GetLimits.cpp
+++ b/toolbox/src/GetLimits.cpp
@@ -292,10 +292,10 @@ bool GetLimits::output(const BlockInformation* blockInfo)
         }
     }
 
-    Signal minPort = blockInfo->getOutputPortSignal(OutputIndex::MinLimit);
-    Signal maxPort = blockInfo->getOutputPortSignal(OutputIndex::MaxLimit);
+    OutputSignalPtr minPort = blockInfo->getOutputPortSignal(OutputIndex::MinLimit);
+    OutputSignalPtr maxPort = blockInfo->getOutputPortSignal(OutputIndex::MaxLimit);
 
-    if (!minPort.isValid() || !maxPort.isValid()) {
+    if (!minPort || !maxPort) {
         wbtError << "Output signals not valid.";
         return false;
     }
@@ -304,8 +304,8 @@ bool GetLimits::output(const BlockInformation* blockInfo)
     const auto dofs = getRobotInterface()->getConfiguration().getNumberOfDoFs();
 
     bool ok = true;
-    ok = ok && minPort.setBuffer(pImpl->limits.min.data(), dofs);
-    ok = ok && maxPort.setBuffer(pImpl->limits.max.data(), dofs);
+    ok = ok && minPort->setBuffer(pImpl->limits.min.data(), dofs);
+    ok = ok && maxPort->setBuffer(pImpl->limits.max.data(), dofs);
 
     if (!ok) {
         wbtError << "Failed to set output buffers.";

--- a/toolbox/src/GetMeasurement.cpp
+++ b/toolbox/src/GetMeasurement.cpp
@@ -338,14 +338,14 @@ bool GetMeasurement::output(const BlockInformation* blockInfo)
     }
 
     // Get the output signal
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::Measurement);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::Measurement);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
 
     // Fill the output buffer
-    if (!output.setBuffer(pImpl->measurement.data(), output.getWidth())) {
+    if (!output->setBuffer(pImpl->measurement.data(), output->getWidth())) {
         wbtError << "Failed to set output buffer.";
         return false;
     }

--- a/toolbox/src/InverseDynamics.cpp
+++ b/toolbox/src/InverseDynamics.cpp
@@ -202,7 +202,7 @@ bool InverseDynamics::output(const BlockInformation* blockInfo)
         wbtError << "Base Acceleration signal not valid.";
         return false;
     }
-    double* bufBaseAcc = baseAccelerationSignal.getBuffer<double>();
+    const double* bufBaseAcc = baseAccelerationSignal.getBuffer<double>();
 
     for (unsigned i = 0; i < baseAccelerationSignal.getWidth(); ++i) {
         if (!pImpl->baseAcceleration.setVal(i, bufBaseAcc[i])) {
@@ -220,7 +220,7 @@ bool InverseDynamics::output(const BlockInformation* blockInfo)
         wbtError << "Joints Acceleration signal not valid.";
         return false;
     }
-    double* bufJointsAcc = jointsAccelerationSignal.getBuffer<double>();
+    const double* bufJointsAcc = jointsAccelerationSignal.getBuffer<double>();
 
     for (unsigned i = 0; i < jointsAccelerationSignal.getWidth(); ++i) {
         if (!pImpl->jointsAcceleration.setVal(i, bufJointsAcc[i])) {

--- a/toolbox/src/Jacobian.cpp
+++ b/toolbox/src/Jacobian.cpp
@@ -212,15 +212,15 @@ bool Jacobian::output(const BlockInformation* blockInfo)
     // GET THE SIGNALS POPULATE THE ROBOT STATE
     // ========================================
 
-    const Signal basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
-    const Signal jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
+    InputSignalPtr basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
+    InputSignalPtr jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
 
-    if (!basePoseSig.isValid() || !jointsPosSig.isValid()) {
+    if (!basePoseSig || !jointsPosSig) {
         wbtError << "Input signals not valid.";
         return false;
     }
 
-    bool ok = setRobotState(&basePoseSig, &jointsPosSig, nullptr, nullptr, kinDyn.get());
+    bool ok = setRobotState(basePoseSig, jointsPosSig, nullptr, nullptr, kinDyn.get());
 
     if (!ok) {
         wbtError << "Failed to set the robot state.";
@@ -252,8 +252,8 @@ bool Jacobian::output(const BlockInformation* blockInfo)
     }
 
     // Get the output signal memory location
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::Jacobian);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::Jacobian);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
@@ -261,7 +261,7 @@ bool Jacobian::output(const BlockInformation* blockInfo)
     // Allocate objects for row-major -> col-major conversion
     Map<MatrixXdiDynTree> jacobianRowMajor = toEigen(pImpl->jacobian);
     Map<MatrixXdSimulink> jacobianColMajor(
-        output.getBuffer<double>(),
+        output->getBuffer<double>(),
         blockInfo->getOutputPortMatrixSize(OutputIndex::Jacobian).first,
         blockInfo->getOutputPortMatrixSize(OutputIndex::Jacobian).second);
 

--- a/toolbox/src/MassMatrix.cpp
+++ b/toolbox/src/MassMatrix.cpp
@@ -145,15 +145,15 @@ bool MassMatrix::output(const BlockInformation* blockInfo)
     // GET THE SIGNALS POPULATE THE ROBOT STATE
     // ========================================
 
-    const Signal basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
-    const Signal jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
+    InputSignalPtr basePoseSig = blockInfo->getInputPortSignal(InputIndex::BasePose);
+    InputSignalPtr jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
 
-    if (!basePoseSig.isValid() || !jointsPosSig.isValid()) {
+    if (!basePoseSig || !jointsPosSig) {
         wbtError << "Input signals not valid.";
         return false;
     }
 
-    bool ok = setRobotState(&basePoseSig, &jointsPosSig, nullptr, nullptr, kinDyn.get());
+    bool ok = setRobotState(basePoseSig, jointsPosSig, nullptr, nullptr, kinDyn.get());
 
     if (!ok) {
         wbtError << "Failed to set the robot state.";
@@ -167,8 +167,8 @@ bool MassMatrix::output(const BlockInformation* blockInfo)
     kinDyn->getFreeFloatingMassMatrix(pImpl->massMatrix);
 
     // Get the output signal memory location
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::MassMatrix);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::MassMatrix);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
@@ -176,7 +176,7 @@ bool MassMatrix::output(const BlockInformation* blockInfo)
     // Allocate objects for row-major -> col-major conversion
     Map<MatrixXdiDynTree> massMatrixRowMajor = toEigen(pImpl->massMatrix);
     Map<MatrixXdSimulink> massMatrixColMajor(
-        output.getBuffer<double>(),
+        output->getBuffer<double>(),
         blockInfo->getOutputPortMatrixSize(OutputIndex::MassMatrix).first,
         blockInfo->getOutputPortMatrixSize(OutputIndex::MassMatrix).second);
 

--- a/toolbox/src/MinimumJerkTrajectoryGenerator.cpp
+++ b/toolbox/src/MinimumJerkTrajectoryGenerator.cpp
@@ -252,13 +252,14 @@ bool MinimumJerkTrajectoryGenerator::initialize(BlockInformation* blockInfo)
 bool MinimumJerkTrajectoryGenerator::output(const BlockInformation* blockInfo)
 {
     if (pImpl->readExternalSettlingTime) {
-        const Signal externalTimeSignal = blockInfo->getInputPortSignal(InputIndex_ExtSettlingTime);
-        if (!externalTimeSignal.isValid()) {
+        InputSignalPtr externalTimeSignal =
+            blockInfo->getInputPortSignal(InputIndex_ExtSettlingTime);
+        if (!externalTimeSignal) {
             wbtError << "Input signal not valid.";
             return false;
         }
 
-        const double externalTime = externalTimeSignal.get<double>(0);
+        const double externalTime = externalTimeSignal->get<double>(0);
 
         if (std::abs(pImpl->previousSettlingTime - externalTime) > 1e-5) {
             pImpl->previousSettlingTime = externalTime;
@@ -273,14 +274,14 @@ bool MinimumJerkTrajectoryGenerator::output(const BlockInformation* blockInfo)
     if (pImpl->firstRun) {
         pImpl->firstRun = false;
 
-        const Signal initialValuesSignal = blockInfo->getInputPortSignal(InputIndex_InitialValue);
-        if (!initialValuesSignal.isValid()) {
+        InputSignalPtr initialValuesSignal = blockInfo->getInputPortSignal(InputIndex_InitialValue);
+        if (!initialValuesSignal) {
             wbtError << "Input signal not valid.";
             return false;
         }
 
-        for (unsigned i = 0; i < initialValuesSignal.getWidth(); ++i) {
-            pImpl->initialValues[i] = initialValuesSignal.get<double>(i);
+        for (unsigned i = 0; i < initialValuesSignal->getWidth(); ++i) {
+            pImpl->initialValues[i] = initialValuesSignal->get<double>(i);
         }
         pImpl->generator->init(pImpl->initialValues);
     }
@@ -288,14 +289,14 @@ bool MinimumJerkTrajectoryGenerator::output(const BlockInformation* blockInfo)
     // Input signal
     // ------------
 
-    const Signal referencesSignal = blockInfo->getInputPortSignal(InputIndex::InputSignal);
-    if (!referencesSignal.isValid()) {
+    InputSignalPtr referencesSignal = blockInfo->getInputPortSignal(InputIndex::InputSignal);
+    if (!referencesSignal) {
         wbtError << "Input signal not valid.";
         return false;
     }
 
-    for (unsigned i = 0; i < referencesSignal.getWidth(); ++i) {
-        pImpl->reference[i] = referencesSignal.get<double>(i);
+    for (unsigned i = 0; i < referencesSignal->getWidth(); ++i) {
+        pImpl->reference[i] = referencesSignal->get<double>(i);
     }
 
     pImpl->generator->computeNextValues(pImpl->reference);
@@ -305,13 +306,13 @@ bool MinimumJerkTrajectoryGenerator::output(const BlockInformation* blockInfo)
     // Output signal
     // -------------
 
-    Signal outputSignal = blockInfo->getOutputPortSignal(OutputIndex::FilteredSignal);
-    if (!outputSignal.isValid()) {
+    OutputSignalPtr outputSignal = blockInfo->getOutputPortSignal(OutputIndex::FilteredSignal);
+    if (!outputSignal) {
         wbtError << "Output signal not valid.";
         return false;
     }
 
-    if (!outputSignal.setBuffer(signal.data(), signal.size())) {
+    if (!outputSignal->setBuffer(signal.data(), signal.size())) {
         wbtError << "Failed to set output buffer.";
         return false;
     }
@@ -321,13 +322,15 @@ bool MinimumJerkTrajectoryGenerator::output(const BlockInformation* blockInfo)
 
     if (pImpl->computeFirstDerivative) {
         const yarp::sig::Vector& derivative = pImpl->generator->getVel();
-        Signal firstDerivativeSignal = blockInfo->getOutputPortSignal(OutputIndex_FirstDer);
-        if (!firstDerivativeSignal.isValid()) {
+        OutputSignalPtr firstDerivativeSignal =
+            blockInfo->getOutputPortSignal(OutputIndex_FirstDer);
+        if (!firstDerivativeSignal) {
             wbtError << "Output signal not valid.";
             return false;
         }
 
-        if (!firstDerivativeSignal.setBuffer(derivative.data(), firstDerivativeSignal.getWidth())) {
+        if (!firstDerivativeSignal->setBuffer(derivative.data(),
+                                              firstDerivativeSignal->getWidth())) {
             wbtError << "Failed to set output buffer.";
             return false;
         }
@@ -338,14 +341,15 @@ bool MinimumJerkTrajectoryGenerator::output(const BlockInformation* blockInfo)
 
     if (pImpl->computeSecondDerivative) {
         const yarp::sig::Vector& derivative = pImpl->generator->getAcc();
-        Signal secondDerivativeSignal = blockInfo->getOutputPortSignal(OutputIndex_SecondDer);
-        if (!secondDerivativeSignal.isValid()) {
+        OutputSignalPtr secondDerivativeSignal =
+            blockInfo->getOutputPortSignal(OutputIndex_SecondDer);
+        if (!secondDerivativeSignal) {
             wbtError << "Output signal not valid.";
             return false;
         }
 
-        if (!secondDerivativeSignal.setBuffer(derivative.data(),
-                                              secondDerivativeSignal.getWidth())) {
+        if (!secondDerivativeSignal->setBuffer(derivative.data(),
+                                               secondDerivativeSignal->getWidth())) {
             wbtError << "Failed to set output buffer.";
             return false;
         }

--- a/toolbox/src/ModelPartitioner.cpp
+++ b/toolbox/src/ModelPartitioner.cpp
@@ -202,8 +202,8 @@ bool ModelPartitioner::output(const BlockInformation* blockInfo)
     const auto& configuration = robotInterface->getConfiguration();
 
     if (pImpl->vectorToControlBoards) {
-        const Signal dofsSignal = blockInfo->getInputPortSignal(0);
-        if (!dofsSignal.isValid()) {
+        InputSignalPtr dofsSignal = blockInfo->getInputPortSignal(0);
+        if (!dofsSignal) {
             wbtError << "Failed to get the input signal buffer.";
             return false;
         }
@@ -219,16 +219,16 @@ bool ModelPartitioner::output(const BlockInformation* blockInfo)
                 pImpl->jointNameToIndexInControlBoardMap->at(ithJointName);
 
             // Get the data to forward
-            Signal ithOutput = blockInfo->getOutputPortSignal(controlBoardOfJoint);
-            if (!ithOutput.set(jointIdxInCB, dofsSignal.get<double>(ithJoint))) {
+            OutputSignalPtr ithOutput = blockInfo->getOutputPortSignal(controlBoardOfJoint);
+            if (!ithOutput->set(jointIdxInCB, dofsSignal->get<double>(ithJoint))) {
                 wbtError << "Failed to set the output signal.";
                 return false;
             }
         }
     }
     else {
-        Signal dofsSignal = blockInfo->getOutputPortSignal(0);
-        if (!dofsSignal.isValid()) {
+        OutputSignalPtr dofsSignal = blockInfo->getOutputPortSignal(0);
+        if (!dofsSignal) {
             wbtError << "Failed to get the input signal buffer.";
             return false;
         }
@@ -244,8 +244,8 @@ bool ModelPartitioner::output(const BlockInformation* blockInfo)
                 pImpl->jointNameToIndexInControlBoardMap->at(ithJointName);
 
             // Get the data to forward
-            const Signal ithInput = blockInfo->getInputPortSignal(controlBoardOfJoint);
-            if (!dofsSignal.set(ithJoint, ithInput.get<double>(jointIdxInCB))) {
+            InputSignalPtr ithInput = blockInfo->getInputPortSignal(controlBoardOfJoint);
+            if (!dofsSignal->set(ithJoint, ithInput->get<double>(jointIdxInCB))) {
                 wbtError << "Failed to set the output signal.";
                 return false;
             }

--- a/toolbox/src/QpOases.cpp
+++ b/toolbox/src/QpOases.cpp
@@ -350,11 +350,11 @@ bool QpOases::output(const BlockInformation* blockInfo)
     // OPTIONAL INPUTS
     // ===============
 
-    double* constraints = nullptr;
-    double* lbA = nullptr;
-    double* ubA = nullptr;
-    double* lb = nullptr;
-    double* ub = nullptr;
+    const double* constraints = nullptr;
+    const double* lbA = nullptr;
+    const double* ubA = nullptr;
+    const double* lb = nullptr;
+    const double* ub = nullptr;
 
     if (pImpl->useLbA || pImpl->useUbA) {
         const Signal constraintsSignal = blockInfo->getInputPortSignal(InputIndex_constraints);
@@ -368,7 +368,7 @@ bool QpOases::output(const BlockInformation* blockInfo)
         using MatrixXdSimulink = Matrix<double, Dynamic, Dynamic, Eigen::ColMajor>;
 
         Map<MatrixXdSimulink> constraints_colMajor(
-            constraintsSignal.getBuffer<double>(),
+            const_cast<double*>(constraintsSignal.getBuffer<double>()),
             blockInfo->getInputPortMatrixSize(InputIndex_constraints).first,
             blockInfo->getInputPortMatrixSize(InputIndex_constraints).second);
         pImpl->constraints_rowMajor = constraints_colMajor;

--- a/toolbox/src/RelativeTransform.cpp
+++ b/toolbox/src/RelativeTransform.cpp
@@ -205,15 +205,15 @@ bool RelativeTransform::output(const BlockInformation* blockInfo)
     // GET THE SIGNALS
     // ===============
 
-    const Signal jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
+    InputSignalPtr jointsPosSig = blockInfo->getInputPortSignal(InputIndex::JointConfiguration);
 
-    if (!jointsPosSig.isValid()) {
+    if (!jointsPosSig) {
         wbtError << "Input signals not valid.";
         return false;
     }
 
-    for (unsigned i = 0; i < jointsPosSig.getWidth(); ++i) {
-        pImpl->jointConfiguration.setVal(i, jointsPosSig.get<double>(i));
+    for (unsigned i = 0; i < jointsPosSig->getWidth(); ++i) {
+        pImpl->jointConfiguration.setVal(i, jointsPosSig->get<double>(i));
     }
 
     kinDyn->setJointPos(pImpl->jointConfiguration);
@@ -227,8 +227,8 @@ bool RelativeTransform::output(const BlockInformation* blockInfo)
     frame1_H_frame2 = kinDyn->getRelativeTransform(pImpl->frame1Index, pImpl->frame2Index);
 
     // Get the output signal memory location
-    Signal output = blockInfo->getOutputPortSignal(OutputIndex::Transform);
-    if (!output.isValid()) {
+    OutputSignalPtr output = blockInfo->getOutputPortSignal(OutputIndex::Transform);
+    if (!output) {
         wbtError << "Output signal not valid.";
         return false;
     }
@@ -236,7 +236,7 @@ bool RelativeTransform::output(const BlockInformation* blockInfo)
     // Allocate objects for row-major -> col-major conversion
     Map<const Matrix4diDynTree> frame1_H_frame2_RowMajor =
         toEigen(frame1_H_frame2.asHomogeneousTransform());
-    Map<Matrix4dSimulink> frame1_H_frame2_ColMajor(output.getBuffer<double>(), 4, 4);
+    Map<Matrix4dSimulink> frame1_H_frame2_ColMajor(output->getBuffer<double>(), 4, 4);
 
     // Forward the buffer to Simulink transforming it to ColMajor
     frame1_H_frame2_ColMajor = frame1_H_frame2_RowMajor;

--- a/toolbox/src/SetReferences.cpp
+++ b/toolbox/src/SetReferences.cpp
@@ -59,14 +59,16 @@ public:
     double refSpeed;
     std::vector<double> defaultRefSpeed;
 
+    std::vector<double> degBufferReferences;
     std::vector<double> previousReferenceVocabCmPosition;
 
-    static void rad2deg(double* buffer, const unsigned width)
+    static void rad2deg(const double* buffer, const unsigned width, std::vector<double>& bufferDeg)
     {
-        const double Rad2Deg = 180.0 / M_PI;
+        bufferDeg.resize(width);
+        constexpr double Rad2Deg = 180.0 / M_PI;
 
         for (unsigned i = 0; i < width; ++i) {
-            buffer[i] *= Rad2Deg;
+            bufferDeg[i] = buffer[i] * Rad2Deg;
         }
     }
 };
@@ -333,7 +335,7 @@ bool SetReferences::output(const BlockInformation* blockInfo)
         return false;
     }
 
-    double* bufferReferences = references.getBuffer<double>();
+    const double* bufferReferences = references.getBuffer<double>();
     if (!bufferReferences) {
         wbtError << "Failed to get the buffer containing references.";
         return false;
@@ -362,9 +364,9 @@ bool SetReferences::output(const BlockInformation* blockInfo)
                 return false;
             }
             // Convert from rad to deg
-            SetReferences::impl::rad2deg(bufferReferences, signalWidth);
+            SetReferences::impl::rad2deg(bufferReferences, signalWidth, pImpl->degBufferReferences);
             // Set the references
-            ok = interface->positionMove(bufferReferences);
+            ok = interface->positionMove(pImpl->degBufferReferences.data());
             break;
         }
         case VOCAB_CM_POSITION_DIRECT: {
@@ -375,9 +377,9 @@ bool SetReferences::output(const BlockInformation* blockInfo)
                 return false;
             }
             // Convert from rad to deg
-            SetReferences::impl::rad2deg(bufferReferences, signalWidth);
+            SetReferences::impl::rad2deg(bufferReferences, signalWidth, pImpl->degBufferReferences);
             // Set the references
-            ok = interface->setPositions(bufferReferences);
+            ok = interface->setPositions(pImpl->degBufferReferences.data());
             break;
         }
         case VOCAB_CM_VELOCITY: {
@@ -388,9 +390,9 @@ bool SetReferences::output(const BlockInformation* blockInfo)
                 return false;
             }
             // Convert from rad to deg
-            SetReferences::impl::rad2deg(bufferReferences, signalWidth);
+            SetReferences::impl::rad2deg(bufferReferences, signalWidth, pImpl->degBufferReferences);
             // Set the references
-            ok = interface->velocityMove(bufferReferences);
+            ok = interface->velocityMove(pImpl->degBufferReferences.data());
             break;
         }
         case VOCAB_CM_TORQUE: {

--- a/toolbox/src/SetReferences.cpp
+++ b/toolbox/src/SetReferences.cpp
@@ -327,15 +327,15 @@ bool SetReferences::output(const BlockInformation* blockInfo)
     }
 
     // Get the signal
-    const Signal references = blockInfo->getInputPortSignal(InputIndex::References);
-    const unsigned signalWidth = references.getWidth();
-
-    if (!references.isValid()) {
+    InputSignalPtr references = blockInfo->getInputPortSignal(InputIndex::References);
+    if (!references) {
         wbtError << "Input signal not valid.";
         return false;
     }
 
-    const double* bufferReferences = references.getBuffer<double>();
+    const unsigned signalWidth = references->getWidth();
+    const double* bufferReferences = references->getBuffer<double>();
+
     if (!bufferReferences) {
         wbtError << "Failed to get the buffer containing references.";
         return false;

--- a/toolbox/src/YarpClock.cpp
+++ b/toolbox/src/YarpClock.cpp
@@ -95,13 +95,13 @@ bool YarpClock::terminate(const BlockInformation* /*blockInfo*/)
 
 bool YarpClock::output(const BlockInformation* blockInfo)
 {
-    Signal outputSignal = blockInfo->getOutputPortSignal(OutputIndex::Clock);
-    if (!outputSignal.isValid()) {
+    OutputSignalPtr outputSignal = blockInfo->getOutputPortSignal(OutputIndex::Clock);
+    if (!outputSignal) {
         wbtError << "Output signal not valid.";
         return false;
     }
 
-    if (!outputSignal.set(0, yarp::os::Time::now())) {
+    if (!outputSignal->set(0, yarp::os::Time::now())) {
         wbtError << "Failed to write data to the output signal.";
         return false;
     }

--- a/toolbox/src/YarpRead.cpp
+++ b/toolbox/src/YarpRead.cpp
@@ -302,29 +302,39 @@ bool YarpRead::output(const BlockInformation* blockInfo)
                 return false;
             }
 
-            Signal timestampSignal = blockInfo->getOutputPortSignal(OutputIndex_Timestamp);
-            timestampSignal.set(0, timestamp.getCount());
-            timestampSignal.set(1, timestamp.getTime());
+            OutputSignalPtr timestampSignal = blockInfo->getOutputPortSignal(OutputIndex_Timestamp);
+            if (!timestampSignal) {
+                wbtError << "Output signal not valid.";
+                return false;
+            }
+
+            timestampSignal->set(0, timestamp.getCount());
+            timestampSignal->set(1, timestamp.getTime());
         }
 
-        Signal signal = blockInfo->getOutputPortSignal(OutputIndex::Signal);
+        OutputSignalPtr signal = blockInfo->getOutputPortSignal(OutputIndex::Signal);
 
-        if (!signal.isValid()) {
+        if (!signal) {
             wbtError << "Output signal not valid.";
             return false;
         }
 
         // Crop the buffer if it exceeds the OutputPortWidth.
-        if (!signal.setBuffer(
+        if (!signal->setBuffer(
                 vectorBuffer->data(),
-                std::min(signal.getWidth(), static_cast<int>(vectorBuffer->size())))) {
+                std::min(signal->getWidth(), static_cast<int>(vectorBuffer->size())))) {
             wbtError << "Failed to set the output buffer.";
             return false;
         }
 
         if (!pImpl->autoconnect) {
-            Signal statusPort = blockInfo->getOutputPortSignal(OutputIndex_IsConnected);
-            if (!statusPort.set(0, 1)) {
+            OutputSignalPtr statusPort = blockInfo->getOutputPortSignal(OutputIndex_IsConnected);
+            if (!statusPort) {
+                wbtError << "Output signal not valid.";
+                return false;
+            }
+
+            if (!statusPort->set(0, 1)) {
                 wbtError << "Failed to write data to output buffer.";
                 return false;
             }

--- a/toolbox/src/YarpWrite.cpp
+++ b/toolbox/src/YarpWrite.cpp
@@ -210,18 +210,18 @@ bool YarpWrite::terminate(const BlockInformation* /*blockInfo*/)
 
 bool YarpWrite::output(const BlockInformation* blockInfo)
 {
-    const Signal signal = blockInfo->getInputPortSignal(InputIndex::Signal);
+    InputSignalPtr signal = blockInfo->getInputPortSignal(InputIndex::Signal);
 
-    if (!signal.isValid()) {
+    if (!signal) {
         wbtError << "Input signal not valid.";
         return false;
     }
 
     pImpl->outputVector = pImpl->port.prepare();
-    pImpl->outputVector.resize(signal.getWidth()); // this should be a no-op
+    pImpl->outputVector.resize(signal->getWidth()); // this should be a no-op
 
-    for (unsigned i = 0; i < signal.getWidth(); ++i) {
-        pImpl->outputVector[i] = signal.get<double>(i);
+    for (unsigned i = 0; i < signal->getWidth(); ++i) {
+        pImpl->outputVector[i] = signal->get<double>(i);
     }
 
     pImpl->port.write();

--- a/toolbox/src/base/CoderBlockInformation.cpp
+++ b/toolbox/src/base/CoderBlockInformation.cpp
@@ -90,8 +90,8 @@ BlockInformation::VectorSize CoderBlockInformation::getOutputPortWidth(const Por
     return pImpl->outputPortDimensions.at(idx).at(1);
 }
 
-wbt::Signal CoderBlockInformation::getInputPortSignal(const PortIndex idx,
-                                                      const VectorSize size) const
+const wbt::Signal CoderBlockInformation::getInputPortSignal(const PortIndex idx,
+                                                            const VectorSize size) const
 {
     if (pImpl->inputSignals.find(idx) == pImpl->inputSignals.end()) {
         wbtError << "Trying to get non-existing signal " << idx << ".";
@@ -256,11 +256,10 @@ bool CoderBlockInformation::setInputSignal(const PortIndex portNumber,
 
     // Store the input signal
     // TODO: hardcoded DataType::DOUBLE
-    bool isConst = true;
     pImpl->inputSignals.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(portNumber),
-        std::forward_as_tuple(Signal::DataFormat::CONTIGUOUS_ZEROCOPY, DataType::DOUBLE, isConst));
+        std::forward_as_tuple(Signal::DataFormat::CONTIGUOUS_ZEROCOPY, DataType::DOUBLE));
 
     // Compute the width of the signal
     unsigned numElements = 1;
@@ -304,11 +303,10 @@ bool CoderBlockInformation::setOutputSignal(const PortIndex portNumber,
 
     // Store the output signal
     // TODO: hardcoded DataType::DOUBLE
-    bool isConst = false;
     pImpl->outputSignals.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(portNumber),
-        std::forward_as_tuple(Signal::DataFormat::CONTIGUOUS_ZEROCOPY, DataType::DOUBLE, isConst));
+        std::forward_as_tuple(Signal::DataFormat::CONTIGUOUS_ZEROCOPY, DataType::DOUBLE));
 
     // Compute the width of the signal
     unsigned numElements = 1;

--- a/toolbox/src/base/Signal.cpp
+++ b/toolbox/src/base/Signal.cpp
@@ -194,7 +194,7 @@ bool Signal::isValid() const
     return pImpl->bufferPtr && (pImpl->width > 0);
 }
 
-void Signal::setWidth(const unsigned& width)
+void Signal::setWidth(const unsigned width)
 {
     pImpl->width = width;
 }
@@ -214,7 +214,7 @@ Signal::DataFormat Signal::getDataFormat() const
     return pImpl->dataFormat;
 }
 
-bool Signal::set(const unsigned& index, const double& data)
+bool Signal::set(const unsigned index, const double data)
 {
     if (pImpl->width <= index) {
         wbtError << "The signal index exceeds its width.";
@@ -250,14 +250,14 @@ bool Signal::set(const unsigned& index, const double& data)
 // ================================
 template double* Signal::getBuffer<double>();
 template const double* Signal::getBuffer<double>() const;
-template double Signal::get<double>(const unsigned& i) const;
-template bool Signal::setBuffer<double>(const double* data, const unsigned& length);
+template double Signal::get<double>(const unsigned i) const;
+template bool Signal::setBuffer<double>(const double* data, const unsigned length);
 
 // Template definitions
 // ===================
 
 template <typename T>
-T Signal::get(const unsigned& i) const
+T Signal::get(const unsigned i) const
 {
     const T* buffer = getBuffer<T>();
 
@@ -318,7 +318,7 @@ const T* Signal::getBuffer() const
 }
 
 template <typename T>
-bool Signal::setBuffer(const T* data, const unsigned& length)
+bool Signal::setBuffer(const T* data, const unsigned length)
 {
     // Non contiguous signals follow the Simulink convention of being read-only.
     // They are used only for input signals.

--- a/toolbox/src/base/Signal.cpp
+++ b/toolbox/src/base/Signal.cpp
@@ -26,18 +26,19 @@ class Signal::impl
 {
 public:
     int width = Signal::DynamicSize;
-    const bool isConst;
     const DataType portDataType;
     const DataFormat dataFormat;
 
     void* bufferPtr = nullptr;
 
+    template <typename T>
+    T* getBufferImpl();
+
     void deleteBuffer();
     void allocateBuffer(const void* const bufferInput, void*& bufferOutput, const unsigned& length);
 
-    impl(const DataFormat& dFormat, const DataType& dType, const bool& c)
-        : isConst(c)
-        , portDataType(dType)
+    impl(const DataFormat& dFormat, const DataType& dType)
+        : portDataType(dType)
         , dataFormat(dFormat)
     {}
 
@@ -117,8 +118,8 @@ Signal::Signal(const Signal& other)
     }
 }
 
-Signal::Signal(const DataFormat& dataFormat, const DataType& dataType, const bool& isConst)
-    : pImpl{new impl(dataFormat, dataType, isConst)}
+Signal::Signal(const DataFormat& dataFormat, const DataType& dataType)
+    : pImpl{new impl(dataFormat, dataType)}
 {}
 
 Signal::Signal(Signal&& other)
@@ -208,11 +209,6 @@ DataType Signal::getPortDataType() const
     return pImpl->portDataType;
 }
 
-bool Signal::isConst() const
-{
-    return pImpl->isConst;
-}
-
 Signal::DataFormat Signal::getDataFormat() const
 {
     return pImpl->dataFormat;
@@ -220,8 +216,8 @@ Signal::DataFormat Signal::getDataFormat() const
 
 bool Signal::set(const unsigned& index, const double& data)
 {
-    if (pImpl->isConst || pImpl->width <= index) {
-        wbtError << "The signal is either const or the index exceeds its width.";
+    if (pImpl->width <= index) {
+        wbtError << "The signal index exceeds its width.";
         return false;
     }
 
@@ -252,7 +248,8 @@ bool Signal::set(const unsigned& index, const double& data)
 
 // Explicit template instantiations
 // ================================
-template double* Signal::getBuffer<double>() const;
+template double* Signal::getBuffer<double>();
+template const double* Signal::getBuffer<double>() const;
 template double Signal::get<double>(const unsigned& i) const;
 template bool Signal::setBuffer<double>(const double* data, const unsigned& length);
 
@@ -262,7 +259,7 @@ template bool Signal::setBuffer<double>(const double* data, const unsigned& leng
 template <typename T>
 T Signal::get(const unsigned& i) const
 {
-    T* buffer = getBuffer<T>();
+    const T* buffer = getBuffer<T>();
 
     if (!buffer) {
         wbtError << "The buffer inside the signal has not been initialized properly.";
@@ -278,7 +275,7 @@ T Signal::get(const unsigned& i) const
 }
 
 template <typename T>
-T* Signal::getBuffer() const
+T* Signal::impl::getBufferImpl()
 {
     const std::map<DataType, size_t> mapDataTypeToHash = {
         {DataType::DOUBLE, typeid(double).hash_code()},
@@ -291,7 +288,7 @@ T* Signal::getBuffer() const
         {DataType::UINT32, typeid(uint32_t).hash_code()},
         {DataType::BOOLEAN, typeid(bool).hash_code()}};
 
-    if (!pImpl->bufferPtr) {
+    if (!bufferPtr) {
         wbtError << "The pointer to data is null. The signal was not configured properly.";
         return nullptr;
     }
@@ -299,13 +296,25 @@ T* Signal::getBuffer() const
     // Check the returned matches the same type of the portType.
     // If this is not met, applying pointer arithmetics on the returned
     // pointer would show unknown behaviour.
-    if (typeid(T).hash_code() != mapDataTypeToHash.at(pImpl->portDataType)) {
-        wbtError << "Trying to get the buffer using a type different that its DataType";
+    if (typeid(T).hash_code() != mapDataTypeToHash.at(portDataType)) {
+        wbtError << "Trying to get the buffer using a type different than its DataType";
         return nullptr;
     }
 
-    // Return the correct pointer
-    return static_cast<T*>(pImpl->bufferPtr);
+    // Cast pointer and return it
+    return static_cast<T*>(bufferPtr);
+}
+
+template <typename T>
+T* Signal::getBuffer()
+{
+    return pImpl->getBufferImpl<T>();
+}
+
+template <typename T>
+const T* Signal::getBuffer() const
+{
+    return pImpl->getBufferImpl<T>();
 }
 
 template <typename T>
@@ -313,8 +322,8 @@ bool Signal::setBuffer(const T* data, const unsigned& length)
 {
     // Non contiguous signals follow the Simulink convention of being read-only.
     // They are used only for input signals.
-    if (pImpl->dataFormat == DataFormat::NONCONTIGUOUS || pImpl->isConst) {
-        wbtError << "Changing buffer address to NONCONTIGUOUS and const signals is not allowed.";
+    if (pImpl->dataFormat == DataFormat::NONCONTIGUOUS) {
+        wbtError << "Changing buffer address to NONCONTIGUOUS is not allowed.";
         return false;
     }
 

--- a/toolbox/src/base/SimulinkBlockInformation.cpp
+++ b/toolbox/src/base/SimulinkBlockInformation.cpp
@@ -277,8 +277,8 @@ BlockInformation::VectorSize SimulinkBlockInformation::getOutputPortWidth(const 
     return ssGetOutputPortWidth(simstruct, idx);
 }
 
-Signal SimulinkBlockInformation::getInputPortSignal(const PortIndex idx,
-                                                    const VectorSize size) const
+const Signal SimulinkBlockInformation::getInputPortSignal(const PortIndex idx,
+                                                          const VectorSize size) const
 {
     // Read if the signal is contiguous or non-contiguous
     boolean_T isContiguous = ssGetInputPortRequiredContiguous(simstruct, idx);
@@ -308,10 +308,7 @@ Signal SimulinkBlockInformation::getInputPortSignal(const PortIndex idx,
     switch (sigDataFormat) {
         case Signal::DataFormat::CONTIGUOUS_ZEROCOPY: {
             // Initialize the signal
-            bool isConstPort = true;
-            Signal signal(Signal::DataFormat::CONTIGUOUS_ZEROCOPY,
-                          mapSimulinkToPortType(dataType),
-                          isConstPort);
+            Signal signal(Signal::DataFormat::CONTIGUOUS_ZEROCOPY, mapSimulinkToPortType(dataType));
             signal.setWidth(signalSize);
             // Initialize signal's data
             if (!signal.initializeBufferFromContiguousZeroCopy(
@@ -324,9 +321,7 @@ Signal SimulinkBlockInformation::getInputPortSignal(const PortIndex idx,
         }
         case Signal::DataFormat::NONCONTIGUOUS: {
             // Initialize the signal
-            bool isConstPort = true;
-            Signal signal(
-                Signal::DataFormat::NONCONTIGUOUS, mapSimulinkToPortType(dataType), isConstPort);
+            Signal signal(Signal::DataFormat::NONCONTIGUOUS, mapSimulinkToPortType(dataType));
             signal.setWidth(signalSize);
             // Initialize signal's data
             InputPtrsType port = ssGetInputPortSignalPtrs(simstruct, idx);
@@ -369,9 +364,7 @@ wbt::Signal SimulinkBlockInformation::getOutputPortSignal(const PortIndex idx,
     // Get the data type of the Signal if set (default: double)
     DTypeId dataType = ssGetOutputPortDataType(simstruct, idx);
 
-    bool isConstPort = false;
-    Signal signal(
-        Signal::DataFormat::CONTIGUOUS_ZEROCOPY, mapSimulinkToPortType(dataType), isConstPort);
+    Signal signal(Signal::DataFormat::CONTIGUOUS_ZEROCOPY, mapSimulinkToPortType(dataType));
     signal.setWidth(signalSize);
 
     if (!signal.initializeBufferFromContiguousZeroCopy(ssGetOutputPortSignal(simstruct, idx))) {

--- a/toolbox/src/base/WBBlock.cpp
+++ b/toolbox/src/base/WBBlock.cpp
@@ -72,10 +72,10 @@ const std::shared_ptr<wbt::RobotInterface> WBBlock::getRobotInterface() const
     return m_robotInterface;
 }
 
-bool WBBlock::setRobotState(const wbt::Signal* basePose,
-                            const wbt::Signal* jointsPos,
-                            const wbt::Signal* baseVelocity,
-                            const wbt::Signal* jointsVelocity,
+bool WBBlock::setRobotState(wbt::InputSignalPtr basePose,
+                            wbt::InputSignalPtr jointsPos,
+                            wbt::InputSignalPtr baseVelocity,
+                            wbt::InputSignalPtr jointsVelocity,
                             iDynTree::KinDynComputations* kinDyn)
 {
     // SAVE THE ROBOT STATE

--- a/toolbox/src/base/WBBlock.cpp
+++ b/toolbox/src/base/WBBlock.cpp
@@ -95,7 +95,7 @@ bool WBBlock::setRobotState(const wbt::Signal* basePose,
 
     if (basePose) {
         // Get the buffer
-        double* buffer = basePose->getBuffer<double>();
+        const double* buffer = basePose->getBuffer<double>();
         if (!buffer) {
             wbtError << "Failed to read the base pose from input port.";
             return false;
@@ -109,7 +109,7 @@ bool WBBlock::setRobotState(const wbt::Signal* basePose,
 
     if (jointsPos) {
         // Get the buffer
-        double* buffer = jointsPos->getBuffer<double>();
+        const double* buffer = jointsPos->getBuffer<double>();
         if (!buffer) {
             wbtError << "Failed to read joints positions from input port.";
             return false;
@@ -125,7 +125,7 @@ bool WBBlock::setRobotState(const wbt::Signal* basePose,
 
     if (baseVelocity) {
         // Get the buffer
-        double* buffer = baseVelocity->getBuffer<double>();
+        const double* buffer = baseVelocity->getBuffer<double>();
         if (!buffer) {
             wbtError << "Failed to read the base velocity from input port.";
             return false;
@@ -139,7 +139,7 @@ bool WBBlock::setRobotState(const wbt::Signal* basePose,
 
     if (jointsVelocity) {
         // Get the buffer
-        double* buffer = jointsVelocity->getBuffer<double>();
+        const double* buffer = jointsVelocity->getBuffer<double>();
         if (!buffer) {
             wbtError << "Failed to read joints velocities from input port.";
             return false;


### PR DESCRIPTION
The last refactor of Signal which introduced templates for getting a setting the handled buffer introduced a subtle bug which allows to modify the buffer from const objects.

In fact, the function `T* getBuffer() const` was returning a pointer which could be used to change the buffer content.

This PR enforces the const correctness, and removes the former logic`Signal::isConst()`. The `BlockInformation` interface has been updated to return a `const Signal` for block's inputs. 