### PR TITLE
Memory leak fix

### DIFF
--- a/toolbox/src/core/src/WBToolbox.cpp
+++ b/toolbox/src/core/src/WBToolbox.cpp
@@ -162,7 +162,7 @@ static void mdlInitializeSizes(SimStruct* S)
 
     // Allocate the block from the Factory.
     // At this stage, the object is just temporary.
-    wbt::Block* block;
+    std::unique_ptr<wbt::Block> block;
     {
         // Allocate the factory
         shlibpp::SharedLibraryClassFactory<wbt::Block> factory(
@@ -175,7 +175,7 @@ static void mdlInitializeSizes(SimStruct* S)
         }
 
         // Allocate the block from the factory
-        block = factory.create();
+        block.reset(factory.create());
     }
 
     // Notify errors


### PR DESCRIPTION
This leak was introduced after the switch to the plugin-based loading of the block library. In the mdlInitializeSizes step the block memory was not cleaned, and the associated RobotInterface block was never deallocated.

This causes a series of issues. Firstly, the toolbox never reaches a clean status when a simulation ends. Secondly, Matlab doesn't close properly and manually killing the process is necessary.

Fixes https://github.com/robotology/wb-toolbox/issues/142