### PR TITLE
Fix qpOASES block stopping behavior

### DIFF
--- a/doc/release/v4.1.md
+++ b/doc/release/v4.1.md
@@ -1,0 +1,34 @@
+# WB-Toolbox (YYYY-MM-DD) Release Notes {[`#v4.1`](https://github.com/robotology/wb-toolbox/releases/tag/v4.1)}
+
+[Description]
+
+## Important Changes
+
+## New Features
+
+### `ToolboxCore`
+
+### `WBToolboxLibrary`
+
+### `WBToolboxMex`
+
+### `WBToolboxCoder`
+
+## Bug Fixes
+
+### `ToolboxCore`
+
+### `WBToolboxLibrary`
+
+- Fixed failing behavior of qpOASES block [#158](https://github.com/robotology/wb-toolbox/issues/158)
+
+### `WBToolboxMex`
+
+### `WBToolboxCoder`
+
+## Contributors
+
+This is a list of people that contributed to this release (generated from the git history using `git shortlog -ens --no-merges vW.X..vY.Z`):
+
+```
+```

--- a/toolbox/library/src/QpOases.cpp
+++ b/toolbox/library/src/QpOases.cpp
@@ -400,7 +400,7 @@ bool QpOases::output(const BlockInformation* blockInfo)
         InputSignalPtr lbSignal = blockInfo->getInputPortSignal(InputIndex_lb);
         lb = lbSignal->getBuffer<double>();
         if (!lbSignal) {
-            wbtError << "Signal for lbA is not valid.";
+            wbtError << "Signal for lb is not valid.";
             return false;
         }
     }

--- a/toolbox/library/src/QpOases.cpp
+++ b/toolbox/library/src/QpOases.cpp
@@ -487,7 +487,7 @@ bool QpOases::output(const BlockInformation* blockInfo)
     const qpOASES::returnValue statusSol =
         pImpl->sqProblem->getPrimalSolution(solutionSignal->getBuffer<double>());
 
-    if (statusSol != qpOASES::SUCCESSFUL_RETURN) {
+    if (pImpl->stopWhenFails && statusSol != qpOASES::SUCCESSFUL_RETURN) {
         wbtError << "qpOASES: getPrimalSolution() failed.";
         return false;
     }


### PR DESCRIPTION
The block was following the user choice about stopping only if the solver failed its initialization (either a cold initialization or hotstart).

However, if the primal solution could not be computed, the block was stopping in any case. This PR fixes this behavior.

cc @gabrielenava

Fixes #158