### PR TITLE
Fix Travis in the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,12 @@ before_script:
       --env-file "$TRAVIS_BUILD_DIR/.ci/env-file" \
       $DOCKER_IMAGE_NAME \
       bash
+  # Fix the image waiting that current WBT master is used in the superbuild
+  - >-
+    docker exec -it \
+      -w /projects/robotology-superbuild/build/robotology/BlockFactory \
+      ci \
+      make install
 
 script:
   - docker exec ci ./.ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,13 +117,15 @@ stage_deploy:
     - export GH_REPO_ORG=${TRAVIS_REPO_SLUG%*/*}
     - export GH_REPO_NAME=${TRAVIS_REPO_SLUG#*/*}
     - export GH_REPO_REF="github.com/$GH_REPO_ORG/$GH_REPO_NAME.git"
-    # Select the deploy folder
-    - if [ "$TRAVIS_BRANCH" = "master" ] ; then DEPLOY_FOLDER=$GH_PAGES_ROOTDIR ; fi
-    - if [ "$TRAVIS_BRANCH" = "devel" ] ; then DEPLOY_FOLDER=$GH_PAGES_ROOTDIR/devel ; fi
     # Check if the gh-pages branch exists and clone it
     - cd $TRAVIS_BUILD_DIR
     - git ls-remote --heads --exit-code https://$GH_REPO_REF gh-pages || travis_terminate 1
     - git clone -b gh-pages https://$GH_REPO_REF $GH_PAGES_ROOTDIR
+    # Select the deploy folder
+    - if [ "$TRAVIS_BRANCH" = "master" ] ; then DEPLOY_FOLDER=$GH_PAGES_ROOTDIR ; fi
+    - if [ "$TRAVIS_BRANCH" = "devel" ] ; then DEPLOY_FOLDER=$GH_PAGES_ROOTDIR/devel ; fi
+    # Create the deploy folder if it does not exist
+    - mkdir -p $DEPLOY_FOLDER
     # Push only the current branch
     - cd $GH_PAGES_ROOTDIR
     - git config push.default simple


### PR DESCRIPTION
In the docker image used to ship dependencies for the Linux stage, `blockfactory@master` is installed before `wb-toolbox@v4.1`. Both ship `shlibpp` dependency, and the most updated is provided by BlockFactory. This means that the WBT `v4.1` overrides it.

When the CI starts, it clones the current v5 version of WBT, it finds its new BlockFactory dependency, but the old `shlibpp` imported target.

This PR installs again the BlockFactory dependency inside the docker image, restoring the right version of `shlibpp`.