### PR TITLE
Fix yarp::os::Network problems

### DIFF
--- a/doc/release/v5.1.md
+++ b/doc/release/v5.1.md
@@ -16,6 +16,8 @@
 
 ### `WBToolbox`
 
+- Fixed calls to `yarp::os::Network` [#171](https://github.com/robotology/wb-toolbox/issues/171)
+
 ## Contributors
 
 This is a list of people that contributed to this release (generated from the git history using `git shortlog -ens --no-merges vW.X..vY.Z`):

--- a/doc/release/v5.1.md
+++ b/doc/release/v5.1.md
@@ -1,0 +1,24 @@
+# Whole-Body Toolbox (YYYY-MM-DD) Release Notes {[`#v5.1`](https://github.com/robotology/wb-toolbox/releases/tag/v5.1)}
+
+[Description]
+
+## Important Changes
+
+## New Features
+
+### `WBToolboxBase`
+
+### `WBToolbox`
+
+## Bug Fixes
+
+### `WBToolboxBase`
+
+### `WBToolbox`
+
+## Contributors
+
+This is a list of people that contributed to this release (generated from the git history using `git shortlog -ens --no-merges vW.X..vY.Z`):
+
+```
+```

--- a/toolbox/base/src/RobotInterface.cpp
+++ b/toolbox/base/src/RobotInterface.cpp
@@ -54,6 +54,7 @@ struct YarpInterfaces
 class RobotInterface::impl
 {
 public:
+    std::unique_ptr<yarp::os::Network> network = nullptr;
     std::unique_ptr<yarp::dev::PolyDriver> robotDevice;
     std::shared_ptr<iDynTree::KinDynComputations> kinDynComp;
     YarpInterfaces yarpInterfaces;
@@ -144,8 +145,11 @@ public:
 
     bool initializeRemoteControlBoardRemapper()
     {
+        if (!network) {
+            network = std::make_unique<yarp::os::Network>();
+        }
+
         // Initialize the network
-        yarp::os::Network::init();
         if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
             bfError << "YARP server wasn't found active.";
             return false;
@@ -220,8 +224,6 @@ RobotInterface::~RobotInterface()
     if (pImpl->robotDevice) {
         pImpl->robotDevice->close();
     }
-    // Finalize the network
-    yarp::os::Network::fini();
 }
 
 // GET METHODS

--- a/toolbox/library/include/WBToolbox/Block/YarpClock.h
+++ b/toolbox/library/include/WBToolbox/Block/YarpClock.h
@@ -30,9 +30,13 @@ namespace blockfactory {
  */
 class wbt::block::YarpClock final : public blockfactory::core::Block
 {
+private:
+    class impl;
+    std::unique_ptr<impl> pImpl;
+
 public:
-    YarpClock() = default;
-    ~YarpClock() override = default;
+    YarpClock();
+    ~YarpClock() override;
 
     unsigned numberOfParameters() override;
     bool configureSizeAndPorts(blockfactory::core::BlockInformation* blockInfo) override;

--- a/toolbox/library/src/RealTimeSynchronizer.cpp
+++ b/toolbox/library/src/RealTimeSynchronizer.cpp
@@ -39,6 +39,7 @@ public:
     double period = 0.01;
     double initialTime;
     unsigned long counter = 0;
+    std::unique_ptr<yarp::os::Network> network = nullptr;
 };
 
 // BLOCK CLASS
@@ -118,7 +119,7 @@ bool RealTimeSynchronizer::initialize(BlockInformation* blockInfo)
     // CLASS INITIALIZATION
     // ====================
 
-    yarp::os::Network::init();
+    pImpl->network = std::make_unique<yarp::os::Network>();
     if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
         bfError << "YARP server wasn't found active!!";
         return false;
@@ -129,7 +130,6 @@ bool RealTimeSynchronizer::initialize(BlockInformation* blockInfo)
 
 bool RealTimeSynchronizer::terminate(const BlockInformation* /*blockInfo*/)
 {
-    yarp::os::Network::fini();
     return true;
 }
 

--- a/toolbox/library/src/SimulatorSynchronizer.cpp
+++ b/toolbox/library/src/SimulatorSynchronizer.cpp
@@ -41,6 +41,7 @@ class SimulatorSynchronizer::impl
 public:
     double period = 0.01;
     bool firstRun = true;
+    std::unique_ptr<yarp::os::Network> network = nullptr;
 
     struct RPCData
     {
@@ -146,8 +147,8 @@ bool SimulatorSynchronizer::initialize(BlockInformation* blockInfo)
     // CLASS INITIALIZATION
     // ====================
 
-    yarp::os::Network::init();
-    if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork()) {
+    pImpl->network = std::make_unique<yarp::os::Network>();
+    if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
         bfError << "Error initializing Yarp network.";
         return false;
     }
@@ -170,7 +171,7 @@ bool SimulatorSynchronizer::terminate(const BlockInformation* /*blockInfo*/)
         }
         pImpl->rpcData.clientPort.close();
     }
-    yarp::os::Network::fini();
+
     return true;
 }
 

--- a/toolbox/library/src/YarpClock.cpp
+++ b/toolbox/library/src/YarpClock.cpp
@@ -28,8 +28,23 @@ enum OutputIndex
     Clock = 0,
 };
 
+// BLOCK PIMPL
+// ===========
+
+class YarpClock::impl
+{
+public:
+    std::unique_ptr<yarp::os::Network> network = nullptr;
+};
+
 // BLOCK CLASS
 // ===========
+
+YarpClock::YarpClock()
+    : pImpl{new impl()}
+{}
+
+YarpClock::~YarpClock() = default;
 
 unsigned YarpClock::numberOfParameters()
 {
@@ -76,7 +91,7 @@ bool YarpClock::initialize(BlockInformation* blockInfo)
     // CLASS INITIALIZATION
     // ====================
 
-    yarp::os::Network::init();
+    pImpl->network = std::make_unique<yarp::os::Network>();
 
     if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
         bfError << "YARP server wasn't found active.";
@@ -88,7 +103,6 @@ bool YarpClock::initialize(BlockInformation* blockInfo)
 
 bool YarpClock::terminate(const BlockInformation* /*blockInfo*/)
 {
-    yarp::os::Network::fini();
     return true;
 }
 

--- a/toolbox/library/src/YarpRead.cpp
+++ b/toolbox/library/src/YarpRead.cpp
@@ -69,6 +69,7 @@ public:
     std::string sourcePortName;
 
     yarp::os::BufferedPort<yarp::sig::Vector> port;
+    std::unique_ptr<yarp::os::Network> network = nullptr;
 };
 
 // BLOCK CLASS
@@ -214,9 +215,9 @@ bool YarpRead::initialize(BlockInformation* blockInfo)
     // CLASS INITIALIZATION
     // ====================
 
-    Network::init();
+    pImpl->network = std::make_unique<yarp::os::Network>();
 
-    if (!Network::initialized() || !Network::checkNetwork(5.0)) {
+    if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
         bfError << "YARP server wasn't found active.";
         return false;
     }
@@ -265,7 +266,6 @@ bool YarpRead::terminate(const BlockInformation* /*blockInfo*/)
     // Close the port
     pImpl->port.close();
 
-    yarp::os::Network::fini();
     return true;
 }
 

--- a/toolbox/library/src/YarpWrite.cpp
+++ b/toolbox/library/src/YarpWrite.cpp
@@ -51,6 +51,7 @@ public:
 
     std::string destinationPortName;
     yarp::os::BufferedPort<yarp::sig::Vector> port;
+    std::unique_ptr<yarp::os::Network> network = nullptr;
 };
 
 // BLOCK CLASS
@@ -146,9 +147,9 @@ bool YarpWrite::initialize(BlockInformation* blockInfo)
     // CLASS INITIALIZATION
     // ====================
 
-    Network::init();
+    pImpl->network = std::make_unique<yarp::os::Network>();
 
-    if (!Network::initialized() || !Network::checkNetwork(5.0)) {
+    if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
         bfError << "YARP server wasn't found active.";
         return false;
     }
@@ -173,7 +174,7 @@ bool YarpWrite::initialize(BlockInformation* blockInfo)
     }
 
     if (pImpl->autoconnect) {
-        if (!Network::connect(pImpl->port.getName(), pImpl->destinationPortName)) {
+        if (!yarp::os::Network::connect(pImpl->port.getName(), pImpl->destinationPortName)) {
             if (pImpl->errorOnMissingPort) {
                 bfError << "Failed to connect " << pImpl->port.getName() << " to "
                         << pImpl->destinationPortName << ".";
@@ -198,7 +199,6 @@ bool YarpWrite::terminate(const BlockInformation* /*blockInfo*/)
     // Close the port
     pImpl->port.close();
 
-    yarp::os::Network::fini();
     return true;
 }
 


### PR DESCRIPTION
Instead of calling `init()` and `fini()` methods, it is better to store an instance of `yarp::os::Network` inside each class that needs yarp network access.

Fixes #171.