### PR TITLE
Improved compilation time of WBToolbox blocks by optimizing `Blockinitialization()`

### DIFF
--- a/matlab/+WBToolbox/BlockInitialization.m
+++ b/matlab/+WBToolbox/BlockInitialization.m
@@ -16,8 +16,8 @@ try
     blockNameSplit = strsplit(currentBlock,'/');
     topLevel = blockNameSplit{1};
 
-    % Get all the blocks from the top level of the system
-    blocks_system = find_system(topLevel,'LookUnderMasks','on','FollowLinks','on');
+    % Get all the "Config" blocks from the top level of the system (name of block under mask matching 'ImConfig')
+    blocks_system = find_system(topLevel,'LookUnderMasks','on','FollowLinks','on','Regexp','on','Name','ImConfig');
 
     % Get the name of the block's subsystem
     %[blockScopeName,~] = fileparts(blockAbsoluteName);


### PR DESCRIPTION
This is related to https://github.com/robotology/wb-toolbox/issues/189. Refer to those issues for full details.

Improved compilation time of WBToolbox blocks by optimizing `Blockinitialization()` code:
- In `Blockinitialization()` current implementation, we first retrieve the list of all the WBT
  blocks in the model. Then we look for the closest Config block, starting from the block's
  scope, and going up in the tree.
- The optimization consisted in retrieving only the Config blocks (name under mask is `ImConfig`)
  instead of the full list. the reduced list is enough for the second regexp, when looking for
  the closest Config, since only the lines containing `ImConfig` are supposed to match the regexp.
- This change is compatible with the support of multi-config models.