### PR TITLE
Remove deprecated and not used iDynTree headers

### DIFF
--- a/toolbox/base/src/WBBlock.cpp
+++ b/toolbox/base/src/WBBlock.cpp
@@ -16,9 +16,7 @@
 #include <BlockFactory/Core/Parameter.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/AngularMotionVector3.h>
 #include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/LinearMotionVector3.h>
 #include <iDynTree/Core/Transform.h>
 #include <iDynTree/Core/Twist.h>
 #include <iDynTree/Core/VectorDynSize.h>


### PR DESCRIPTION
WBBlock.cpp included some headers of iDynTree that will be deprecated in iDynTree 2,  and in ~~general are not actually used~~ actually they are used, but for compatibility with future iDynTree it is better not too IWYU in this case, as it is possible to compile fine without including them even with iDynTree 1.

This should avoid problems like https://github.com/robotology/robotology-superbuild/issues/422 in the future. 