### PR TITLE
CI: Add Windows support and add periodic build

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 set -e
 
+echo "Creating $HOME/git"
 mkdir $HOME/git
 export CXXFLAGS="-Wno-unused-command-line-argument"
 
 # Install YCM
+echo "Moving to $HOME/git"
 cd $HOME/git
+echo "Running git clone --depth 1 -b $DEPS_BRANCH https://github.com/robotology/ycm.git"
 git clone --depth 1 -b $DEPS_BRANCH https://github.com/robotology/ycm.git
 cd ycm
 mkdir build && cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           export DEPS_CACHE=$HOME/deps
           export PATH=$PATH:$DEPS_CACHE/bin
           export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$DEPS_CACHE
-          ./.ci/install.sh || false
+          bash ./.ci/install.sh || false
         env:
           CMAKE_GENERATOR: "Visual Studio 16 2019"
           CMAKE_BUILD_TYPE: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,17 +53,8 @@ jobs:
           unzip vcpkg-robotology.zip -d C:/
           rm vcpkg-robotology.zip
 
-      - name: Setup dependencies branch [master]
-        if: |
-          github.ref == 'refs/heads/master' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'refs/heads/master')
+      - name: Setup dependencies branch
         run: echo "DEPS_BRANCH=master" >> $GITHUB_ENV
-
-      - name: Setup dependencies branch [other]
-        if: |
-          (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
-          (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
-        run: echo "DEPS_BRANCH=devel" >> $GITHUB_ENV
           
       - name: Install dependencies (Ubuntu and macOS)
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
 
 env:
   VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
+
 jobs:
 
   ci:
@@ -14,6 +17,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
 
     steps:
 
@@ -33,6 +37,18 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install ace assimp eigen tinyxml gsl ipopt ninja
 
+      - name: 'Windows: System Dependencies'
+        if: contains(matrix.os, 'windows')
+        run: |
+          # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need
+          choco install -y wget unzip
+          # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/robotology/vcpkg
+          # that has been used to create the pre-compiled archive
+          cd C:/
+          wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/v0.6.0/vcpkg-robotology.zip
+          unzip vcpkg-robotology.zip -d C:/
+          rm vcpkg-robotology.zip
+
       - name: Setup dependencies branch [master]
         if: |
           github.ref == 'refs/heads/master' ||
@@ -44,8 +60,9 @@ jobs:
           (github.event_name == 'push' && github.ref != 'refs/heads/master') ||
           (github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'refs/heads/master')
         run: echo "DEPS_BRANCH=devel" >> $GITHUB_ENV
-
-      - name: Install dependencies
+          
+      - name: Install dependencies (Ubuntu and macOS)
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
           export DEPS_CACHE=$HOME/deps
           export PATH=$PATH:$DEPS_CACHE/bin
@@ -55,7 +72,8 @@ jobs:
           CMAKE_GENERATOR: Ninja
           CMAKE_BUILD_TYPE: Debug
 
-      - name: Build
+      - name: Build (Ubuntu and macOS)
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
           export DEPS_CACHE=$HOME/deps
           export PATH=$PATH:$DEPS_CACHE/bin
@@ -68,3 +86,31 @@ jobs:
         env:
           CMAKE_GENERATOR: Ninja
           CMAKE_BUILD_TYPE: Debug
+
+      - name: Install dependencies (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: bash
+        run: |
+          source /c/robotology/scripts/setup-deps.sh
+          export DEPS_CACHE=$HOME/deps
+          export PATH=$PATH:$DEPS_CACHE/bin
+          export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$DEPS_CACHE
+          ./.ci/install.sh || false
+        env:
+          CMAKE_GENERATOR: "Visual Studio 16 2019"
+          CMAKE_BUILD_TYPE: Release
+
+      - name: Build
+        run: |
+          source /c/robotology/scripts/setup-deps.sh
+          export DEPS_CACHE=$HOME/deps
+          export PATH=$PATH:$DEPS_CACHE/bin
+          export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$DEPS_CACHE
+          mkdir build && cd build
+          cmake ..\
+            -G"$CMAKE_GENERATOR" \
+            -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+          cmake --build . --config $CMAKE_BUILD_TYPE
+        env:
+          CMAKE_GENERATOR: "Visual Studio 16 2019"
+          CMAKE_BUILD_TYPE: Release


### PR DESCRIPTION
I added a Windows CI job. 

Furthermore, I noticed that the Linux and macOS jobs were failing, mostly due to environment changes (ycm and YARP do not have anymore a devel branch). For this reason, I switched all the jobs to use `master` branches, and added a period nightly job to avoid such regressions in the future.