### PR TITLE
[WIP] QpOases: Switch to use reliable options

### DIFF
--- a/toolbox/library/src/QpOases.cpp
+++ b/toolbox/library/src/QpOases.cpp
@@ -318,7 +318,7 @@ bool QpOases::initialize(BlockInformation* blockInfo)
 
     // Setup safe options
     qpOASES::Options problemOptions;
-    problemOptions.setToDefault();
+    problemOptions.setToReliable();
     pImpl->sqProblem->setOptions(problemOptions);
 
 #ifdef NDEBUG


### PR DESCRIPTION
Fix https://github.com/robotology/wb-toolbox/issues/202 . As per @lrapetti tests, on typical QP instances used in robotic Whole-Body Control the time difference is not big, and using the reliably settings seems safer. 