### PR TITLE
OSQP: Fix missing return in OSQP::solverInitialization and disable OSQP verbose output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+## [5.4.1] - 2021-05-27
+
+### Fixed 
+- Fixed bug that caused Simulink models that used OSQP block to hang indefinitely in "Initializing" or "Compiling" phase (https://github.com/robotology/wb-toolbox/pull/220)
+
 ## [5.4.0] - 2021-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
-## [5.4.1] - 2021-05-27
+## [5.4.1] - 2021-05-26
 
 ### Fixed 
-- Fixed bug that caused Simulink models that used OSQP block to hang indefinitely in "Initializing" or "Compiling" phase (https://github.com/robotology/wb-toolbox/pull/220)
+- Fixed bug that caused Simulink models that used OSQP block to hang indefinitely in "Initializing" or "Compiling" phase (https://github.com/robotology/wb-toolbox/pull/220).
+- Disable verbose output option in OSQP block (https://github.com/robotology/wb-toolbox/pull/220).
 
 ## [5.4.0] - 2021-05-24
 

--- a/toolbox/library/src/OSQP.cpp
+++ b/toolbox/library/src/OSQP.cpp
@@ -316,7 +316,7 @@ bool wbt::block::OSQP::solverInitialization(const BlockInformation*blockInfo)
     pImpl->totalConstraintsMatrix = Eigen::MatrixXd(pImpl->numberOfTotalConstraints, pImpl->numberOfVariables);
 
     // Setup options
-    pImpl->sqSolver->settings()->setVerbosity(true);
+    pImpl->sqSolver->settings()->setVerbosity(false);
 
     // Set adaptive_rho to false to avoid converge problems
     // See https://github.com/oxfordcontrol/osqp/issues/151

--- a/toolbox/library/src/OSQP.cpp
+++ b/toolbox/library/src/OSQP.cpp
@@ -326,7 +326,7 @@ bool wbt::block::OSQP::solverInitialization(const BlockInformation*blockInfo)
     // of hessians, gradient and constraints
     pImpl->sqSolver->settings()->setWarmStart(true);
 
-
+    return true;
 }
 
 bool wbt::block::OSQP::initialize(BlockInformation* blockInfo)


### PR DESCRIPTION
On some platforms and some models that used the OSQP block, this made Simulink hangs in "Initializing" or "Compiling"  stage.