### PR TITLE
Add workflow_dispatch to conda-ci job

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -3,6 +3,7 @@ name: C++ CI Workflow with dependencies installed via conda
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
   # * is a special character in YAML so you have to quote this string
   # Execute a "nightly" build at 2 AM UTC 


### PR DESCRIPTION
To manually retrigger failed cron jobs, without losing the log of the previous failed job (such as https://github.com/robotology/wb-toolbox/actions/runs/1010126085).