### PR TITLE
Fix website generation by moving index.html of the documentation website in main repo

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Populate deploy folder
         run: |
+          cp doc/index.html $DEPLOY_FOLDER/index.html
           rm -rf $DEPLOY_FOLDER/mkdocs
           rm -rf $DEPLOY_FOLDER/doxygen
           cp -r $MKDOCS_INPUT_FOLDER $DEPLOY_FOLDER/mkdocs
@@ -93,4 +94,4 @@ jobs:
           BRANCH: gh-pages
           FOLDER: build/ghpages
           CLEAN: true
-          CLEAN_EXCLUDE: '[".gitignore", ".nojekyll", "index.html"]'
+          CLEAN_EXCLUDE: '[".gitignore", ".nojekyll"]'

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;url=mkdocs/index.html">
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        If you are not redirected automatically, follow the <a href="mkdocs/index.html">link to the documentation</a>
+    </body>
+</html>


### PR DESCRIPTION
Fix https://github.com/robotology/wb-toolbox/issues/207 . 

In particular, this fixes a regression for which index.html files were never updated, probably with the intention of making sure that the index.html contained in the `gh-pages`  (added in https://github.com/robotology/wb-toolbox/commit/8ed7bc06a50bb9c07a7df2a88e69c422d1907c9d#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051) was never overwritten. To avoid this, the `index.html` is now contained in the `doc` directory, and copied in the deploy folder when necessary. This also ensure that everything necessary to generate the documentation website is managed and versioned as part of the main repo.