### PR TITLE
Ensure that the OSQP report as status output not the return value of solveProblem(), but the output of solveProblem()

### DIFF
--- a/toolbox/library/src/OSQP.cpp
+++ b/toolbox/library/src/OSQP.cpp
@@ -599,7 +599,8 @@ bool wbt::block::OSQP::output(const BlockInformation* blockInfo)
     }
 
     // Set status
-    if (!statusSignal->set(0, double(solveReturnVal))) {
+    OsqpEigen::Status status = pImpl->sqSolver->getStatus();
+    if (!statusSignal->set(0, double(status))) {
         bfError << "Failed to set status signal.";
         return false;
     }


### PR DESCRIPTION
As per title this PR contains the fix for the solver status of the Simulink OSQP block.