### PR TITLE
Do the changes to support BlockFactory 1.0.0 and bump version to 6.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 cmake_minimum_required(VERSION 3.5)
-project(WB-Toolbox LANGUAGES CXX VERSION 5.7.0)
+project(WB-Toolbox LANGUAGES CXX VERSION 6.0.0)
 
 if(WBT_BUILD_DOCS)
     add_subdirectory(doc)

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -9,7 +9,7 @@ dependencies:
   - ninja
   - pkg-config
   - eigen 
-  - blockfactory
+  - blockfactory>=1.0.0
   - idyntree 
   - osqp-eigen
   - qpoases 

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-find_package(shlibpp REQUIRED)
+find_package(sharedlibpp REQUIRED)
 find_package(BlockFactory COMPONENTS Core REQUIRED)
 
 add_subdirectory(base)

--- a/toolbox/library/src/Factory.cpp
+++ b/toolbox/library/src/Factory.cpp
@@ -49,7 +49,7 @@
 #include <string>
 
 // Class factory API
-#include "shlibpp/SharedLibraryClassApi.h"
+#include "sharedlibpp/SharedLibraryClassApi.h"
 
 // YARP-dependent blocks
 SHLIBPP_DEFINE_SHARED_SUBCLASS(GetLimits, wbt::block::GetLimits, blockfactory::core::Block)


### PR DESCRIPTION
This PR does the changes required to support (and also require) BlockFactory 1.0.0 . See https://github.com/robotology/blockfactory/pull/87 for more information about BlockFactory 1.0.0 .

As this is effectively a breaking change, the version number is bumped to 6.0.0 .