### PR TITLE
Remove warnings from configuration and compilation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,8 +60,8 @@ Example:
 #include "RobotInterface.h"
 #include "Signal.h"
 
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/SpatialMomentum.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/SpatialMomentum.h>
 #include <iDynTree/KinDynComputations.h>
 
 #include <ostream>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(WB-Toolbox LANGUAGES CXX VERSION 6.0.0)
 
 if(WBT_BUILD_DOCS)

--- a/toolbox/base/CMakeLists.txt
+++ b/toolbox/base/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(WBToolboxBase
     YARP::YARP_init
     YARP::YARP_dev
     iDynTree::idyntree-model
-    iDynTree::idyntree-modelio-urdf
+    iDynTree::idyntree-modelio
     iDynTree::idyntree-high-level)
 
 target_include_directories(WBToolboxBase PUBLIC

--- a/toolbox/base/src/RobotInterface.cpp
+++ b/toolbox/base/src/RobotInterface.cpp
@@ -11,9 +11,9 @@
 
 #include <BlockFactory/Core/Log.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/FreeFloatingMatrices.h>
-#include <iDynTree/Model/Indices.h>
-#include <iDynTree/Model/Model.h>
+#include <iDynTree/FreeFloatingMatrices.h>
+#include <iDynTree/Indices.h>
+#include <iDynTree/Model.h>
 #include <iDynTree/ModelIO/ModelLoader.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>

--- a/toolbox/base/src/RobotInterface.cpp
+++ b/toolbox/base/src/RobotInterface.cpp
@@ -14,7 +14,7 @@
 #include <iDynTree/FreeFloatingMatrices.h>
 #include <iDynTree/Indices.h>
 #include <iDynTree/Model.h>
-#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/ModelLoader.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Bottle.h>

--- a/toolbox/base/src/WBBlock.cpp
+++ b/toolbox/base/src/WBBlock.cpp
@@ -16,11 +16,11 @@
 #include <BlockFactory/Core/Parameter.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/Transform.h>
-#include <iDynTree/Core/Twist.h>
-#include <iDynTree/Core/VectorDynSize.h>
-#include <iDynTree/Core/VectorFixSize.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/Transform.h>
+#include <iDynTree/Twist.h>
+#include <iDynTree/VectorDynSize.h>
+#include <iDynTree/VectorFixSize.h>
 #include <iDynTree/KinDynComputations.h>
 
 #include <array>

--- a/toolbox/library/CMakeLists.txt
+++ b/toolbox/library/CMakeLists.txt
@@ -101,7 +101,7 @@ list(APPEND WBTOOLBOXLIBRARY_EXT_LIBRARIES
     YARP::YARP_math
     iDynTree::idyntree-core
     iDynTree::idyntree-model
-    iDynTree::idyntree-modelio-urdf
+    iDynTree::idyntree-modelio
     iDynTree::idyntree-high-level)
 
 # Additional dependency of the SimulatorSynchronizer block

--- a/toolbox/library/src/CentroidalMomentum.cpp
+++ b/toolbox/library/src/CentroidalMomentum.cpp
@@ -13,8 +13,8 @@
 #include <BlockFactory/Core/BlockInformation.h>
 #include <BlockFactory/Core/Log.h>
 #include <BlockFactory/Core/Signal.h>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/SpatialMomentum.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/SpatialMomentum.h>
 #include <iDynTree/KinDynComputations.h>
 
 #include <ostream>

--- a/toolbox/library/src/CentroidalTotalMomentumMatrix.cpp
+++ b/toolbox/library/src/CentroidalTotalMomentumMatrix.cpp
@@ -16,11 +16,11 @@
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/MatrixDynSize.h>
-#include <iDynTree/Core/Transform.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/MatrixDynSize.h>
+#include <iDynTree/Transform.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Indices.h>
 
 #include <memory>
 #include <ostream>

--- a/toolbox/library/src/DotJNu.cpp
+++ b/toolbox/library/src/DotJNu.cpp
@@ -15,10 +15,10 @@
 #include <BlockFactory/Core/Parameter.h>
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/VectorFixSize.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/VectorFixSize.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Indices.h>
 
 #include <memory>
 #include <ostream>

--- a/toolbox/library/src/ForwardKinematics.cpp
+++ b/toolbox/library/src/ForwardKinematics.cpp
@@ -16,10 +16,10 @@
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/Transform.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/Transform.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Indices.h>
 
 #include <ostream>
 #include <tuple>

--- a/toolbox/library/src/GetLimits.cpp
+++ b/toolbox/library/src/GetLimits.cpp
@@ -16,9 +16,9 @@
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/IJoint.h>
-#include <iDynTree/Model/Indices.h>
-#include <iDynTree/Model/Model.h>
+#include <iDynTree/IJoint.h>
+#include <iDynTree/Indices.h>
+#include <iDynTree/Model.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
 
 #include <cmath>

--- a/toolbox/library/src/InverseDynamics.cpp
+++ b/toolbox/library/src/InverseDynamics.cpp
@@ -14,14 +14,14 @@
 #include <BlockFactory/Core/Log.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/VectorDynSize.h>
-#include <iDynTree/Core/VectorFixSize.h>
-#include <iDynTree/Core/Wrench.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/VectorDynSize.h>
+#include <iDynTree/VectorFixSize.h>
+#include <iDynTree/Wrench.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/FreeFloatingState.h>
-#include <iDynTree/Model/JointState.h>
-#include <iDynTree/Model/LinkState.h>
+#include <iDynTree/FreeFloatingState.h>
+#include <iDynTree/JointState.h>
+#include <iDynTree/LinkState.h>
 
 #include <memory>
 #include <ostream>

--- a/toolbox/library/src/InverseKinematics.cpp
+++ b/toolbox/library/src/InverseKinematics.cpp
@@ -7,7 +7,7 @@
 #include <Eigen/Core>
 #include <iCub/iKin/iKinFwd.h>
 #include <iCub/iKin/iKinIpOpt.h>
-#include <iDynTree/Model/DenavitHartenberg.h>
+#include <iDynTree/DenavitHartenberg.h>
 #include <iDynTree/ModelIO/ModelLoader.h>
 #include <iDynTree/iKinConversions.h>
 #include <wbi/wholeBodyInterface.h>

--- a/toolbox/library/src/InverseKinematics.cpp
+++ b/toolbox/library/src/InverseKinematics.cpp
@@ -8,7 +8,7 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <iCub/iKin/iKinIpOpt.h>
 #include <iDynTree/DenavitHartenberg.h>
-#include <iDynTree/ModelIO/ModelLoader.h>
+#include <iDynTree/ModelLoader.h>
 #include <iDynTree/iKinConversions.h>
 #include <wbi/wholeBodyInterface.h>
 #include <yarp/os/ResourceFinder.h>

--- a/toolbox/library/src/Jacobian.cpp
+++ b/toolbox/library/src/Jacobian.cpp
@@ -16,11 +16,11 @@
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/MatrixDynSize.h>
-#include <iDynTree/Core/Transform.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/MatrixDynSize.h>
+#include <iDynTree/Transform.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Indices.h>
 
 #include <memory>
 #include <ostream>

--- a/toolbox/library/src/MassMatrix.cpp
+++ b/toolbox/library/src/MassMatrix.cpp
@@ -14,8 +14,8 @@
 #include <BlockFactory/Core/Log.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/MatrixDynSize.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/MatrixDynSize.h>
 #include <iDynTree/KinDynComputations.h>
 
 #include <ostream>

--- a/toolbox/library/src/RelativeJacobian.cpp
+++ b/toolbox/library/src/RelativeJacobian.cpp
@@ -16,11 +16,11 @@
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/MatrixDynSize.h>
-#include <iDynTree/Core/Transform.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/MatrixDynSize.h>
+#include <iDynTree/Transform.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Indices.h>
 
 #include <memory>
 #include <ostream>

--- a/toolbox/library/src/RelativeTransform.cpp
+++ b/toolbox/library/src/RelativeTransform.cpp
@@ -16,10 +16,10 @@
 #include <BlockFactory/Core/Parameters.h>
 #include <BlockFactory/Core/Signal.h>
 #include <Eigen/Core>
-#include <iDynTree/Core/EigenHelpers.h>
-#include <iDynTree/Core/Transform.h>
+#include <iDynTree/EigenHelpers.h>
+#include <iDynTree/Transform.h>
 #include <iDynTree/KinDynComputations.h>
-#include <iDynTree/Model/Indices.h>
+#include <iDynTree/Indices.h>
 
 #include <ostream>
 


### PR DESCRIPTION
The headers were deprecated in iDynTree 10.0.0 released in November 2023: https://github.com/robotology/idyntree/releases/tag/v10.0.0 .

Furthermore, we also switch from linking to `idyntree-modelio-urdf` to `idyntree-modelio`, to avoid the warning:

~~~
2024-12-06T13:09:27.6936842Z CMake Warning (dev) at toolbox/base/CMakeLists.txt:21 (target_link_libraries):
2024-12-06T13:09:27.6937560Z   The library that is being linked to, iDynTree::idyntree-modelio-urdf, is
2024-12-06T13:09:27.6938249Z   marked as being deprecated by the owner.  The message provided by the
2024-12-06T13:09:27.6938775Z   developer is:
2024-12-06T13:09:27.6939077Z 
2024-12-06T13:09:27.6939332Z   Do not use deprecated target iDynTree::idyntree-modelio-urdf, use
2024-12-06T13:09:27.6939859Z   iDynTree::idyntree-modelio instead.
~~~

I also bumped the minimum CMake version to 3.16 to avoid the warning:

~~~
CMake Deprecation Warning at CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
~~~